### PR TITLE
fix: Auto-grow multiline input and fix Claude message bubble width

### DIFF
--- a/apps/mobile/src/__tests__/input-bar.test.ts
+++ b/apps/mobile/src/__tests__/input-bar.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { MIN_INPUT_HEIGHT, MAX_INPUT_HEIGHT } from '../utils/inputBarConstants';
 
 /**
  * InputBar layout constants and scroll logic tests.
@@ -6,9 +7,6 @@ import { describe, it, expect } from 'vitest';
  * The TextInput auto-grows via minHeight / maxHeight (no explicit height).
  * scrollEnabled flips to true only when content reaches MAX_INPUT_HEIGHT.
  */
-
-const MIN_INPUT_HEIGHT = 36;
-const MAX_INPUT_HEIGHT = 120;
 
 /** Mirrors the logic inside handleContentSizeChange */
 function computeScrollEnabled(contentHeight: number): boolean {
@@ -30,7 +28,7 @@ describe('InputBar scroll logic', () => {
 
   it('should disable scroll for multi-line content below max', () => {
     expect(computeScrollEnabled(80)).toBe(false);
-    expect(computeScrollEnabled(119)).toBe(false);
+    expect(computeScrollEnabled(MAX_INPUT_HEIGHT - 1)).toBe(false);
   });
 
   it('should enable scroll when content height equals max', () => {

--- a/apps/mobile/src/__tests__/terminal-layout.test.ts
+++ b/apps/mobile/src/__tests__/terminal-layout.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { parseToolUsage } from '../utils/terminalUtils';
 
 /**
  * Terminal message bubble layout and utility tests.
@@ -6,26 +7,6 @@ import { describe, it, expect } from 'vitest';
  * Validates that bubble containers use correct flex properties so
  * Claude messages fill available width instead of collapsing.
  */
-
-/** Mirrors parseToolUsage from Terminal.tsx */
-function parseToolUsage(content: string): { tools: string[]; cleanContent: string } {
-  const toolPattern = /\[Using tool: ([^\]]+)\]/g;
-  const completedPattern = /\[Tool ([^\]]+) completed\]/g;
-
-  const tools: string[] = [];
-  let match;
-
-  while ((match = toolPattern.exec(content)) !== null) {
-    tools.push(match[1]);
-  }
-
-  const cleanContent = content
-    .replace(toolPattern, '')
-    .replace(completedPattern, '')
-    .trim();
-
-  return { tools, cleanContent };
-}
 
 describe('parseToolUsage', () => {
   it('should return empty tools and original content for plain text', () => {

--- a/apps/mobile/src/components/InputBar.tsx
+++ b/apps/mobile/src/components/InputBar.tsx
@@ -23,6 +23,7 @@ import { ModelPicker } from './ModelPicker';
 import { InteractivePicker } from './InteractivePicker';
 import { ResumeSessionPicker } from './ResumeSessionPicker';
 import type { SlashCommand, InteractiveCommandType } from 'termbridge-shared';
+import { MIN_INPUT_HEIGHT, MAX_INPUT_HEIGHT } from '../utils/inputBarConstants';
 
 // Commands that require interactive UI instead of text input
 const INTERACTIVE_COMMANDS = new Set<string>([
@@ -38,9 +39,6 @@ const INTERACTIVE_COMMANDS = new Set<string>([
 interface InputBarProps {
   disabled?: boolean;
 }
-
-const MIN_INPUT_HEIGHT = 36;
-const MAX_INPUT_HEIGHT = 120;
 
 export function InputBar({ disabled }: InputBarProps) {
   const [input, setInput] = useState('');

--- a/apps/mobile/src/components/Terminal.tsx
+++ b/apps/mobile/src/components/Terminal.tsx
@@ -19,6 +19,7 @@ import * as Haptics from 'expo-haptics';
 import { useConnectionStore } from '../stores/connectionStore';
 import { useSessionStore } from '../stores/sessionStore';
 import type { RealtimeMessage } from 'termbridge-shared';
+import { parseToolUsage } from '../utils/terminalUtils';
 
 interface TerminalProps {
   maxLines?: number;
@@ -57,27 +58,6 @@ function ToolBadge({ toolName, isDark }: { toolName: string; isDark: boolean }) 
       </Text>
     </View>
   );
-}
-
-// Parse tool usage from content
-function parseToolUsage(content: string): { tools: string[]; cleanContent: string } {
-  const toolPattern = /\[Using tool: ([^\]]+)\]/g;
-  const completedPattern = /\[Tool ([^\]]+) completed\]/g;
-
-  const tools: string[] = [];
-  let match;
-
-  while ((match = toolPattern.exec(content)) !== null) {
-    tools.push(match[1]);
-  }
-
-  // Remove tool messages from content
-  const cleanContent = content
-    .replace(toolPattern, '')
-    .replace(completedPattern, '')
-    .trim();
-
-  return { tools, cleanContent };
 }
 
 export function Terminal({ maxLines = 1000 }: TerminalProps) {

--- a/apps/mobile/src/utils/inputBarConstants.ts
+++ b/apps/mobile/src/utils/inputBarConstants.ts
@@ -1,0 +1,2 @@
+export const MIN_INPUT_HEIGHT = 36;
+export const MAX_INPUT_HEIGHT = 120;

--- a/apps/mobile/src/utils/terminalUtils.ts
+++ b/apps/mobile/src/utils/terminalUtils.ts
@@ -1,0 +1,20 @@
+/** Parse tool usage markers from Claude message content */
+export function parseToolUsage(content: string): { tools: string[]; cleanContent: string } {
+  const toolPattern = /\[Using tool: ([^\]]+)\]/g;
+  const completedPattern = /\[Tool ([^\]]+) completed\]/g;
+
+  const tools: string[] = [];
+  let match;
+
+  while ((match = toolPattern.exec(content)) !== null) {
+    tools.push(match[1]);
+  }
+
+  // Remove tool messages from content
+  const cleanContent = content
+    .replace(toolPattern, '')
+    .replace(completedPattern, '')
+    .trim();
+
+  return { tools, cleanContent };
+}


### PR DESCRIPTION
## Summary
- Fix chat input field not expanding when typing multiline text by removing fixed height control and letting React Native handle auto-growth via `minHeight`/`maxHeight`
- Fix Claude message bubbles rendering too narrow by adding `flexGrow: 1` to bubble container
- Clean up dead `inputHeight` state — replaced with `isScrollEnabled` boolean that directly expresses intent
- Remove dead code: `onSubmitEditing` (no-op on iOS multiline), redundant `setInputHeight` reset on send

## Tests added
- `input-bar.test.ts`: scroll enable/disable logic based on content height vs MAX_INPUT_HEIGHT, constant sanity checks
- `terminal-layout.test.ts`: `parseToolUsage` extraction, bubble container flex properties, message grouping logic

## Test plan
- [x] Multiline input auto-expands as newlines are added
- [x] Input scrolls when content exceeds max height (120px)
- [x] Input shrinks back when text is cleared
- [x] Claude message bubbles fill proper width with inline code and markdown
- [x] All 146 tests pass (22 new)
- [ ] Verify on physical iOS device

🤖 Generated with [Claude Code](https://claude.com/claude-code)