### PR TITLE
fix: Queue messages during processing & add status sync

### DIFF
--- a/apps/cli/src/__tests__/client.test.ts
+++ b/apps/cli/src/__tests__/client.test.ts
@@ -804,7 +804,7 @@ describe('RealtimeClient', () => {
         payload: expect.objectContaining({
           type: 'error',
           content: errorMessage,
-          errorCode: 'request_rejected',
+          errorCode: 'unknown',
         }),
       });
     });
@@ -826,7 +826,7 @@ describe('RealtimeClient', () => {
         expect.objectContaining({
           type: 'error',
           content: 'Test error',
-          errorCode: 'request_rejected',
+          errorCode: 'unknown',
         })
       );
     });

--- a/apps/cli/src/__tests__/daemon.test.ts
+++ b/apps/cli/src/__tests__/daemon.test.ts
@@ -916,8 +916,8 @@ describe('Daemon', () => {
     });
   });
 
-  describe('request rejection handling', () => {
-    it('should broadcast error when sdkSession emits request-rejected event', async () => {
+  describe('request queuing handling', () => {
+    it('should broadcast request-queued when sdkSession emits request-queued event', async () => {
       daemon = new Daemon({
         cwd: '/test',
         supabase: mockSupabase as SupabaseClient,
@@ -929,25 +929,186 @@ describe('Daemon', () => {
       // Get the sdkSession from daemon
       const sdkSession = (daemon as any).sdkSession;
 
-      // Emit request-rejected event
-      sdkSession.emit('request-rejected', 'Your message was not processed because Claude is still working on the previous request. Please wait.');
+      // Emit request-queued event
+      sdkSession.emit('request-queued');
 
       // Wait for async operations
       await new Promise(resolve => setTimeout(resolve, 10));
 
-      // Verify broadcastError was called via the output channel
+      // Verify broadcastQueued was called via the output channel
       expect(mockOutputChannel.send).toHaveBeenCalledWith({
         type: 'broadcast',
         event: 'output',
         payload: expect.objectContaining({
-          type: 'error',
-          content: 'Your message was not processed because Claude is still working on the previous request. Please wait.',
-          errorCode: 'request_rejected',
+          type: 'request-queued',
         }),
       });
     });
 
-    it('should handle broadcast errors silently when rejecting requests', async () => {
+    it('should re-broadcast pending question on status-request', async () => {
+      let inputHandler: ((payload: any) => void) | null = null;
+
+      mockInputChannel.on = vi.fn((event, filter, handler) => {
+        if (event === 'broadcast' && filter.event === 'input') {
+          inputHandler = handler;
+        }
+        return mockInputChannel as RealtimeChannel;
+      });
+
+      daemon = new Daemon({
+        cwd: '/test',
+        supabase: mockSupabase as SupabaseClient,
+        sessionId: 'session-789',
+      });
+
+      await daemon.start();
+
+      const sdkSession = (daemon as any).sdkSession;
+
+      // Mock a pending question
+      const mockQuestion = {
+        toolUseId: 'tool-123',
+        questions: [{ question: 'Pick one?', header: 'Choice', options: [{ label: 'A', description: 'Option A' }] }],
+      };
+      vi.spyOn(sdkSession, 'getPendingQuestionData').mockReturnValue(mockQuestion);
+      vi.spyOn(sdkSession, 'getPendingPermissionData').mockReturnValue(null);
+
+      const sendSpy = mockOutputChannel.send;
+
+      // Simulate receiving status-request from mobile
+      if (inputHandler) {
+        inputHandler({
+          payload: {
+            type: 'status-request',
+            timestamp: Date.now(),
+            seq: 1,
+          },
+        });
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      // Verify user-question was re-broadcast
+      expect(sendSpy).toHaveBeenCalledWith({
+        type: 'broadcast',
+        event: 'output',
+        payload: expect.objectContaining({
+          type: 'user-question',
+          userQuestion: mockQuestion,
+        }),
+      });
+    });
+
+    it('should re-broadcast pending permission on status-request', async () => {
+      let inputHandler: ((payload: any) => void) | null = null;
+
+      mockInputChannel.on = vi.fn((event, filter, handler) => {
+        if (event === 'broadcast' && filter.event === 'input') {
+          inputHandler = handler;
+        }
+        return mockInputChannel as RealtimeChannel;
+      });
+
+      daemon = new Daemon({
+        cwd: '/test',
+        supabase: mockSupabase as SupabaseClient,
+        sessionId: 'session-789',
+      });
+
+      await daemon.start();
+
+      const sdkSession = (daemon as any).sdkSession;
+
+      // Mock a pending permission request
+      const mockPermission = {
+        requestId: 'req-456',
+        toolName: 'Edit',
+        toolInput: { file_path: '/test.ts' },
+        toolUseId: 'tool-456',
+      };
+      vi.spyOn(sdkSession, 'getPendingQuestionData').mockReturnValue(null);
+      vi.spyOn(sdkSession, 'getPendingPermissionData').mockReturnValue(mockPermission);
+
+      const sendSpy = mockOutputChannel.send;
+
+      // Simulate receiving status-request from mobile
+      if (inputHandler) {
+        inputHandler({
+          payload: {
+            type: 'status-request',
+            timestamp: Date.now(),
+            seq: 1,
+          },
+        });
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      // Verify permission-request was re-broadcast
+      expect(sendSpy).toHaveBeenCalledWith({
+        type: 'broadcast',
+        event: 'output',
+        payload: expect.objectContaining({
+          type: 'permission-request',
+          permissionRequest: mockPermission,
+        }),
+      });
+    });
+
+    it('should re-broadcast pending question on status-request while processing', async () => {
+      let inputHandler: ((payload: any) => void) | null = null;
+
+      mockInputChannel.on = vi.fn((event, filter, handler) => {
+        if (event === 'broadcast' && filter.event === 'input') {
+          inputHandler = handler;
+        }
+        return mockInputChannel as RealtimeChannel;
+      });
+
+      daemon = new Daemon({
+        cwd: '/test',
+        supabase: mockSupabase as SupabaseClient,
+        sessionId: 'session-789',
+      });
+
+      await daemon.start();
+
+      const sdkSession = (daemon as any).sdkSession;
+
+      // Simulate processing state with a pending question
+      const mockQuestion = {
+        toolUseId: 'tool-active',
+        questions: [{ question: 'Pick?', header: 'Q', options: [{ label: 'X', description: 'opt' }] }],
+      };
+      vi.spyOn(sdkSession, 'isActive').mockReturnValue(true);
+      vi.spyOn(sdkSession, 'getPendingQuestionData').mockReturnValue(mockQuestion);
+      vi.spyOn(sdkSession, 'getPendingPermissionData').mockReturnValue(null);
+
+      const sendSpy = mockOutputChannel.send;
+
+      if (inputHandler) {
+        inputHandler({
+          payload: {
+            type: 'status-request',
+            timestamp: Date.now(),
+            seq: 1,
+          },
+        });
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(sendSpy).toHaveBeenCalledWith({
+        type: 'broadcast',
+        event: 'output',
+        payload: expect.objectContaining({
+          type: 'user-question',
+          userQuestion: mockQuestion,
+        }),
+      });
+    });
+
+    it('should handle broadcast errors silently when queuing requests', async () => {
       // Mock output channel to throw error
       mockOutputChannel.send = vi.fn().mockRejectedValue(new Error('Broadcast failed'));
 
@@ -963,7 +1124,7 @@ describe('Daemon', () => {
 
       // Should not throw even if broadcast fails
       expect(() => {
-        sdkSession.emit('request-rejected', 'Test error message');
+        sdkSession.emit('request-queued');
       }).not.toThrow();
 
       // Wait for async operations

--- a/apps/cli/src/__tests__/sdk-session.test.ts
+++ b/apps/cli/src/__tests__/sdk-session.test.ts
@@ -510,8 +510,8 @@ describe('SdkSession', () => {
     });
   });
 
-  describe('request rejection', () => {
-    it('should emit request-rejected event when sendPrompt is called while already processing', async () => {
+  describe('message queuing', () => {
+    it('should emit request-queued and queue the message when sendPrompt is called while processing', async () => {
       // Create a session that takes time to finish
       let resolveStream: (() => void) | null = null;
       const slowSession = {
@@ -528,10 +528,8 @@ describe('SdkSession', () => {
       };
       mockedCreateSession.mockReturnValue(slowSession as any);
 
-      const requestRejectedHandler = vi.fn();
-      const outputHandler = vi.fn();
-      sdkSession.on('request-rejected', requestRejectedHandler);
-      sdkSession.on('output', outputHandler);
+      const queuedHandler = vi.fn();
+      sdkSession.on('request-queued', queuedHandler);
 
       // Start first request (doesn't complete yet)
       const firstPromise = sdkSession.sendPrompt('First message');
@@ -542,15 +540,8 @@ describe('SdkSession', () => {
       // Try to send second request while first is processing
       await sdkSession.sendPrompt('Second message');
 
-      // Verify request-rejected event was emitted
-      expect(requestRejectedHandler).toHaveBeenCalledWith(
-        'Your message was not processed because Claude is still working on the previous request. Please wait.'
-      );
-
-      // Verify output event was also emitted (for terminal)
-      expect(outputHandler).toHaveBeenCalledWith(
-        '\n[TermBridge] Previous request still processing...\n'
-      );
+      // Verify request-queued event was emitted
+      expect(queuedHandler).toHaveBeenCalled();
 
       // Clean up - resolve the slow stream
       if (resolveStream) resolveStream();
@@ -558,9 +549,79 @@ describe('SdkSession', () => {
       await tick();
     });
 
-    it('should not emit request-rejected when sendPrompt is called after previous request completes', async () => {
-      const requestRejectedHandler = vi.fn();
-      sdkSession.on('request-rejected', requestRejectedHandler);
+    it('should auto-send queued message after first request completes', async () => {
+      let resolveStream: (() => void) | null = null;
+      const slowSession = {
+        get sessionId() { return 'slow-session'; },
+        send: vi.fn().mockResolvedValue(undefined),
+        stream: async function* () {
+          yield { type: 'system', subtype: 'init', session_id: 'slow-session' };
+          await new Promise<void>(r => { resolveStream = r; });
+          yield { type: 'result', subtype: 'success', result: 'done' };
+        },
+        close: vi.fn(),
+        [Symbol.asyncDispose]: async () => {},
+      };
+      mockedCreateSession.mockReturnValue(slowSession as any);
+
+      // Start first request
+      const firstPromise = sdkSession.sendPrompt('First message');
+      await tick();
+
+      // Queue second message while processing
+      await sdkSession.sendPrompt('Second message');
+
+      // First request: one send call
+      expect(slowSession.send).toHaveBeenCalledTimes(1);
+
+      // Complete the first request
+      if (resolveStream) resolveStream();
+      await firstPromise;
+      await tick();
+      await tick();
+
+      // The queued message should have been auto-sent
+      expect(slowSession.send).toHaveBeenCalledTimes(2);
+    });
+
+    it('should only keep the last queued message (last-one-wins)', async () => {
+      let resolveStream: (() => void) | null = null;
+      const slowSession = {
+        get sessionId() { return 'slow-session'; },
+        send: vi.fn().mockResolvedValue(undefined),
+        stream: async function* () {
+          yield { type: 'system', subtype: 'init', session_id: 'slow-session' };
+          await new Promise<void>(r => { resolveStream = r; });
+          yield { type: 'result', subtype: 'success', result: 'done' };
+        },
+        close: vi.fn(),
+        [Symbol.asyncDispose]: async () => {},
+      };
+      mockedCreateSession.mockReturnValue(slowSession as any);
+
+      const firstPromise = sdkSession.sendPrompt('First message');
+      await tick();
+
+      // Queue multiple messages - only last should be kept
+      await sdkSession.sendPrompt('Second message');
+      await sdkSession.sendPrompt('Third message');
+
+      // Complete the first request
+      if (resolveStream) resolveStream();
+      await firstPromise;
+      await tick();
+      await tick();
+
+      // The last queued message ('Third message') should be sent
+      expect(slowSession.send).toHaveBeenCalledTimes(2);
+      const lastSendCall = slowSession.send.mock.calls[1][0];
+      const textBlock = lastSendCall.message.content.find((b: any) => b.type === 'text');
+      expect(textBlock.text).toBe('Third message');
+    });
+
+    it('should not emit request-queued when sendPrompt is called after previous request completes', async () => {
+      const queuedHandler = vi.fn();
+      sdkSession.on('request-queued', queuedHandler);
 
       // Send first request and wait for completion
       await sdkSession.sendPrompt('First message');
@@ -569,8 +630,106 @@ describe('SdkSession', () => {
       // Send second request after first completes
       await sdkSession.sendPrompt('Second message');
 
-      // Verify request-rejected was never emitted
-      expect(requestRejectedHandler).not.toHaveBeenCalled();
+      // Verify request-queued was never emitted
+      expect(queuedHandler).not.toHaveBeenCalled();
+    });
+
+    it('should suppress complete event when queued message exists', async () => {
+      let resolveStream: (() => void) | null = null;
+      const slowSession = {
+        get sessionId() { return 'slow-session'; },
+        send: vi.fn().mockResolvedValue(undefined),
+        stream: async function* () {
+          yield { type: 'system', subtype: 'init', session_id: 'slow-session' };
+          await new Promise<void>(r => { resolveStream = r; });
+          yield { type: 'result', subtype: 'success', result: 'done' };
+        },
+        close: vi.fn(),
+        [Symbol.asyncDispose]: async () => {},
+      };
+      mockedCreateSession.mockReturnValue(slowSession as any);
+
+      const completeHandler = vi.fn();
+      sdkSession.on('complete', completeHandler);
+
+      const firstPromise = sdkSession.sendPrompt('First message');
+      await tick();
+
+      // Queue a message
+      await sdkSession.sendPrompt('Second message');
+
+      // Complete the first request
+      if (resolveStream) resolveStream();
+      await firstPromise;
+      await tick();
+
+      // Complete should NOT have been emitted for the first request (suppressed because queued message exists)
+      // It will be emitted when the queued message finishes
+      expect(completeHandler).not.toHaveBeenCalled();
+    });
+
+    it('should clear pending prompt when cancel is called', async () => {
+      let resolveStream: (() => void) | null = null;
+      const slowSession = {
+        closed: false,
+        get sessionId() { return 'slow-session'; },
+        send: vi.fn().mockResolvedValue(undefined),
+        stream: async function* () {
+          yield { type: 'system', subtype: 'init', session_id: 'slow-session' };
+          await new Promise<void>(r => { resolveStream = r; });
+          yield { type: 'result', subtype: 'success', result: 'done' };
+        },
+        close: vi.fn(() => { slowSession.closed = true; }),
+        [Symbol.asyncDispose]: async () => {},
+      };
+      mockedCreateSession.mockReturnValue(slowSession as any);
+
+      sdkSession.sendPrompt('First message');
+      await tick();
+
+      // Queue a message
+      await sdkSession.sendPrompt('Second message');
+
+      // Cancel while processing
+      sdkSession.cancel();
+
+      expect(sdkSession.isActive()).toBe(false);
+
+      // Clean up
+      if (resolveStream) resolveStream();
+      await tick();
+    });
+
+    it('should clear pending prompt when clearHistory is called', async () => {
+      let resolveStream: (() => void) | null = null;
+      const slowSession = {
+        closed: false,
+        get sessionId() { return 'slow-session'; },
+        send: vi.fn().mockResolvedValue(undefined),
+        stream: async function* () {
+          yield { type: 'system', subtype: 'init', session_id: 'slow-session' };
+          await new Promise<void>(r => { resolveStream = r; });
+          yield { type: 'result', subtype: 'success', result: 'done' };
+        },
+        close: vi.fn(() => { slowSession.closed = true; }),
+        [Symbol.asyncDispose]: async () => {},
+      };
+      mockedCreateSession.mockReturnValue(slowSession as any);
+
+      sdkSession.sendPrompt('First message');
+      await tick();
+
+      // Queue a message
+      await sdkSession.sendPrompt('Second message');
+
+      // Clear history while processing
+      sdkSession.clearHistory();
+
+      expect(sdkSession.isActive()).toBe(false);
+
+      // Clean up
+      if (resolveStream) resolveStream();
+      await tick();
     });
   });
 
@@ -754,16 +913,16 @@ describe('SdkSession', () => {
       ]);
       mockedCreateSession.mockReturnValue(normalSession as any);
 
-      const rejectedHandler = vi.fn();
-      sdkSession.on('request-rejected', rejectedHandler);
+      const queuedHandler = vi.fn();
+      sdkSession.on('request-queued', queuedHandler);
 
       // This needs a fresh session since the old one closed
       sdkSession.clearHistory();
       await sdkSession.sendPrompt('Second');
       await tick();
 
-      // Should NOT be rejected
-      expect(rejectedHandler).not.toHaveBeenCalled();
+      // Should NOT be queued (previous request already recovered)
+      expect(queuedHandler).not.toHaveBeenCalled();
       expect(normalSession._sendMock).toHaveBeenCalled();
     });
   });
@@ -864,6 +1023,54 @@ describe('SdkSession', () => {
         }],
         answers: { '0': 'Option A' },
       });
+    });
+
+    it('should track pending question data and clear it after answer', async () => {
+      let capturedCanUseTool: any = null;
+
+      mockedCreateSession.mockImplementation((opts: any) => {
+        capturedCanUseTool = opts.canUseTool;
+        return createMockSession([
+          { type: 'system', subtype: 'init', session_id: 'test-session-id' },
+        ]) as any;
+      });
+
+      sdkSession.sendPrompt('Start');
+      await tick();
+
+      // No pending question initially
+      expect(sdkSession.getPendingQuestionData()).toBeNull();
+
+      // Simulate canUseTool being called
+      const canUseToolPromise = capturedCanUseTool('AskUserQuestion', {
+        questions: [{
+          question: 'Pick one',
+          header: 'Test',
+          options: [{ label: 'A', description: 'Option A' }],
+        }],
+      }, {
+        signal: new AbortController().signal,
+        toolUseID: 'toolu_789',
+      });
+
+      await tick();
+
+      // Pending question should be tracked
+      expect(sdkSession.getPendingQuestionData()).toEqual(
+        expect.objectContaining({
+          toolUseId: 'toolu_789',
+          questions: expect.arrayContaining([
+            expect.objectContaining({ question: 'Pick one' }),
+          ]),
+        })
+      );
+
+      // Answer the question
+      await sdkSession.provideAnswer('A', { '0': 'A' });
+      await canUseToolPromise;
+
+      // Pending question should be cleared
+      expect(sdkSession.getPendingQuestionData()).toBeNull();
     });
 
     it('should fall back to sendPrompt when no pending question exists', async () => {

--- a/apps/cli/src/daemon/daemon.ts
+++ b/apps/cli/src/daemon/daemon.ts
@@ -164,11 +164,11 @@ export class Daemon extends EventEmitter {
       }
     });
 
-    // Wire up request rejection errors to broadcast to mobile
-    this.sdkSession.on('request-rejected', async (errorMessage: string) => {
+    // Wire up request queuing to broadcast to mobile
+    this.sdkSession.on('request-queued', async () => {
       if (this.realtimeClient) {
         try {
-          await this.realtimeClient.broadcastError(errorMessage, 'request_rejected');
+          await this.realtimeClient.broadcastQueued();
         } catch {
           // Silently handle broadcast errors
         }
@@ -276,6 +276,25 @@ export class Daemon extends EventEmitter {
           await this.realtimeClient?.broadcastModel(this.sdkSession.getModel());
         } catch {
           // Silently handle broadcast errors
+        }
+        return;
+      }
+
+      // Handle status request - re-broadcast any pending question or permission
+      if (message.type === 'status-request') {
+        if (this.realtimeClient) {
+          try {
+            const pendingQuestion = this.sdkSession.getPendingQuestionData();
+            if (pendingQuestion) {
+              await this.realtimeClient.broadcastUserQuestion(pendingQuestion);
+            }
+            const pendingPermission = this.sdkSession.getPendingPermissionData();
+            if (pendingPermission) {
+              await this.realtimeClient.broadcastPermissionRequest(pendingPermission);
+            }
+          } catch {
+            // Silently handle broadcast errors
+          }
         }
         return;
       }

--- a/apps/cli/src/daemon/sdk-session.ts
+++ b/apps/cli/src/daemon/sdk-session.ts
@@ -48,8 +48,13 @@ export class SdkSession extends EventEmitter {
   private pendingPermissionRequests: Map<string, PendingPermissionRequest> = new Map();
   // Pending AskUserQuestion answer resolver - resolved by provideAnswer()
   private pendingAnswerResolve: ((answers: Record<string, string>) => void) | null = null;
+  // Track pending question/permission data for re-broadcast on status-request
+  private pendingQuestionData: UserQuestionData | null = null;
+  private pendingPermissionData: PermissionRequestData | null = null;
   // Track current assistant response text for conversation history
   private currentAssistantResponse: string = '';
+  // Queued prompt to send after current processing completes (last-one-wins)
+  private pendingPrompt: { prompt: string; attachments?: ImageAttachment[] } | null = null;
 
   constructor(options: SdkSessionOptions) {
     super();
@@ -69,6 +74,7 @@ export class SdkSession extends EventEmitter {
     }
 
     this.pendingPermissionRequests.delete(response.requestId);
+    this.pendingPermissionData = null;
 
     if (response.behavior === 'allow') {
       const result: PermissionResult = {
@@ -137,7 +143,8 @@ export class SdkSession extends EventEmitter {
             questions,
           };
 
-          // Broadcast to mobile
+          // Store and broadcast to mobile
+          this.pendingQuestionData = questionData;
           this.emit('user-question', questionData);
 
           // Wait for provideAnswer() to supply the answers
@@ -148,12 +155,14 @@ export class SdkSession extends EventEmitter {
               // Clean up if the request is aborted (e.g. session cancelled)
               options.signal.addEventListener('abort', () => {
                 this.pendingAnswerResolve = null;
+                this.pendingQuestionData = null;
                 reject(new Error('Question aborted'));
               });
             }
           );
 
           this.pendingAnswerResolve = null;
+          this.pendingQuestionData = null;
 
           // Return updatedInput so the subprocess can build the tool_result
           return {
@@ -207,7 +216,8 @@ export class SdkSession extends EventEmitter {
         agentId: options.agentID,
       };
 
-      // Emit event for daemon to broadcast to mobile
+      // Store and emit event for daemon to broadcast to mobile
+      this.pendingPermissionData = requestData;
       this.emit('permission-request', requestData);
 
       // Create promise that will be resolved when mobile responds
@@ -221,6 +231,7 @@ export class SdkSession extends EventEmitter {
         // Handle abort
         options.signal.addEventListener('abort', () => {
           this.pendingPermissionRequests.delete(requestId);
+          this.pendingPermissionData = null;
           reject(new Error('Permission request aborted'));
         });
       });
@@ -308,6 +319,7 @@ export class SdkSession extends EventEmitter {
       // requests are not permanently blocked.
       if (this.isProcessing) {
         this.isProcessing = false;
+        this.pendingPrompt = null;
         this.emit('complete');
       }
     }
@@ -373,7 +385,16 @@ export class SdkSession extends EventEmitter {
 
       this.currentAssistantResponse = '';
       this.isProcessing = false;
-      this.emit('complete');
+
+      // Auto-send queued message if one is pending
+      const queued = this.pendingPrompt;
+      if (queued) {
+        this.pendingPrompt = null;
+        // Don't emit 'complete' — mobile isTyping stays true seamlessly
+        this.sendPrompt(queued.prompt, queued.attachments);
+      } else {
+        this.emit('complete');
+      }
     } else if (message.type === 'tool_progress') {
       // Tool progress (tool being used)
       if ('tool_name' in message) {
@@ -389,8 +410,9 @@ export class SdkSession extends EventEmitter {
 
   async sendPrompt(prompt: string, attachments?: ImageAttachment[]): Promise<void> {
     if (this.isProcessing) {
-      this.emit('output', '\n[TermBridge] Previous request still processing...\n');
-      this.emit('request-rejected', 'Your message was not processed because Claude is still working on the previous request. Please wait.');
+      // Queue the message instead of rejecting — last one wins
+      this.pendingPrompt = { prompt, attachments };
+      this.emit('request-queued');
       return;
     }
 
@@ -503,6 +525,7 @@ export class SdkSession extends EventEmitter {
       this.streamLoopRunning = false;
     }
     this.isProcessing = false;
+    this.pendingPrompt = null;
   }
 
   getSessionId(): string | null {
@@ -522,12 +545,21 @@ export class SdkSession extends EventEmitter {
     }
     this.sessionId = sessionId;
     this.isProcessing = false;
+    this.pendingPrompt = null;
     this.conversationHistory = []; // Clear local history since we're resuming a different session
     this.emit('session-resumed', sessionId);
   }
 
   isActive(): boolean {
     return this.isProcessing;
+  }
+
+  getPendingQuestionData(): UserQuestionData | null {
+    return this.pendingQuestionData;
+  }
+
+  getPendingPermissionData(): PermissionRequestData | null {
+    return this.pendingPermissionData;
   }
 
   async setModel(model: string): Promise<void> {
@@ -542,6 +574,7 @@ export class SdkSession extends EventEmitter {
       this.streamLoopRunning = false;
       this.sessionId = null;
       this.isProcessing = false;
+      this.pendingPrompt = null;
       this.pendingContextTransfer = true;
     } else if (this.sessionId) {
       this.sessionId = null;
@@ -569,6 +602,7 @@ export class SdkSession extends EventEmitter {
     }
     this.sessionId = null;
     this.isProcessing = false;
+    this.pendingPrompt = null;
   }
 
   async getSupportedModels(): Promise<ModelInfo[]> {

--- a/apps/cli/src/realtime/client.ts
+++ b/apps/cli/src/realtime/client.ts
@@ -459,6 +459,30 @@ export class RealtimeClient extends EventEmitter {
     this.emit('broadcast', message);
   }
 
+  async broadcastQueued(): Promise<void> {
+    if (!this.outputChannel) {
+      throw new Error('Not connected');
+    }
+
+    if (!this.realtimeEnabled) {
+      return;
+    }
+
+    const message: RealtimeMessage = {
+      type: 'request-queued',
+      timestamp: Date.now(),
+      seq: ++this.seq,
+    };
+
+    await this.outputChannel.send({
+      type: 'broadcast',
+      event: 'output',
+      payload: message,
+    });
+
+    this.emit('broadcast', message);
+  }
+
   async broadcastError(errorMessage: string, errorCode?: string): Promise<void> {
     if (!this.outputChannel) {
       throw new Error('Not connected');
@@ -472,7 +496,7 @@ export class RealtimeClient extends EventEmitter {
     const message: RealtimeMessage = {
       type: 'error',
       content: errorMessage,
-      errorCode: errorCode || 'request_rejected',
+      errorCode: errorCode || 'unknown',
       timestamp: Date.now(),
       seq: ++this.seq,
     };

--- a/apps/mobile/src/components/Terminal.tsx
+++ b/apps/mobile/src/components/Terminal.tsx
@@ -65,7 +65,7 @@ export function Terminal({ maxLines = 1000 }: TerminalProps) {
   const colorScheme = useColorScheme();
   const isDark = colorScheme === 'dark';
 
-  const { messages, state, isTyping, sessionId, registerScrollToBottom } = useConnectionStore();
+  const { messages, state, isTyping, isMessageQueued, sessionId, registerScrollToBottom } = useConnectionStore();
   const { sessionOnlineStatus } = useSessionStore();
   const isCliOnline = sessionId ? (sessionOnlineStatus[sessionId] ?? null) : null;
 
@@ -195,7 +195,7 @@ export function Terminal({ maxLines = 1000 }: TerminalProps) {
             ))}
             {isTyping && (
               <AnimatedBubble>
-                <TypingIndicator isDark={isDark} />
+                <TypingIndicator isDark={isDark} isQueued={isMessageQueued} />
               </AnimatedBubble>
             )}
           </>
@@ -239,9 +239,10 @@ function AnimatedBubble({ children }: { children: React.ReactNode }) {
 
 interface TypingIndicatorProps {
   isDark: boolean;
+  isQueued?: boolean;
 }
 
-function TypingIndicator({ isDark }: TypingIndicatorProps) {
+function TypingIndicator({ isDark, isQueued }: TypingIndicatorProps) {
   return (
     <View style={styles.messageRow}>
       <ClaudeAvatar isDark={isDark} />
@@ -249,7 +250,7 @@ function TypingIndicator({ isDark }: TypingIndicatorProps) {
         <View style={[styles.typingBubble, isDark && styles.typingBubbleDark]}>
           <ActivityIndicator size="small" color={isDark ? '#9ca3af' : '#6b7280'} />
           <Text style={[styles.typingText, isDark && styles.typingTextDark]}>
-            Claude is working...
+            {isQueued ? 'Message queued, Claude is finishing up...' : 'Claude is working...'}
           </Text>
         </View>
       </View>

--- a/apps/mobile/src/stores/connectionStore.ts
+++ b/apps/mobile/src/stores/connectionStore.ts
@@ -27,6 +27,7 @@ interface ConnectionStoreState {
   lastSeq: number;
   error: string | null;
   isTyping: boolean;
+  isMessageQueued: boolean;
   isCliOnline: boolean | null; // Tracks if CLI is online via Supabase Presence (null = not yet checked)
   permissionMode: PermissionMode | null;
   commands: SlashCommand[];
@@ -53,6 +54,7 @@ interface ConnectionStoreState {
   sendModelChange: (model: string) => Promise<void>;
   requestCommands: () => Promise<void>;
   requestModels: () => Promise<void>;
+  requestPendingState: () => Promise<void>;
   clearMessages: () => void;
   clearError: () => void;
   sendClearRequest: () => Promise<void>;
@@ -88,6 +90,7 @@ export const useConnectionStore = create<ConnectionStoreState>((set, get) => ({
   lastSeq: 0,
   error: null,
   isTyping: false,
+  isMessageQueued: false,
   isCliOnline: null, // null = not yet checked
   permissionMode: null,
   commands: [],
@@ -110,6 +113,7 @@ export const useConnectionStore = create<ConnectionStoreState>((set, get) => ({
         messages: [],
         lastSeq: 0,
         isTyping: false,
+        isMessageQueued: false,
         isCliOnline: null, // Reset to unknown until presence syncs
         permissionMode: null,
         commands: [],
@@ -177,10 +181,17 @@ export const useConnectionStore = create<ConnectionStoreState>((set, get) => ({
       outputChannel.on('broadcast', { event: 'output' }, (payload) => {
         const message = payload.payload as RealtimeMessage;
 
+        // Handle request-queued - message was queued because Claude is still processing
+        if (message.type === 'request-queued') {
+          set({ isMessageQueued: true });
+          return;
+        }
+
         // Handle error messages - reset isTyping and show error
         if (message.type === 'error') {
           set({
             isTyping: false,
+            isMessageQueued: false,
             error: message.content || 'An error occurred'
           });
           return;
@@ -246,7 +257,7 @@ export const useConnectionStore = create<ConnectionStoreState>((set, get) => ({
 
         // Handle complete - Claude has finished responding
         if (message.type === 'complete') {
-          set({ isTyping: false });
+          set({ isTyping: false, isMessageQueued: false });
           return;
         }
 
@@ -314,9 +325,10 @@ export const useConnectionStore = create<ConnectionStoreState>((set, get) => ({
 
       set({ state: 'connected' });
 
-      // Request available commands and models from CLI
+      // Request available commands, models, and any pending state from CLI
       get().requestCommands();
       get().requestModels();
+      get().requestPendingState();
     } catch (error) {
       set({
         state: 'disconnected',
@@ -513,6 +525,24 @@ export const useConnectionStore = create<ConnectionStoreState>((set, get) => ({
 
     const message: RealtimeMessage = {
       type: 'models-request',
+      timestamp: Date.now(),
+      seq: ++seq,
+    };
+
+    await inputChannel.send({
+      type: 'broadcast',
+      event: 'input',
+      payload: message,
+    });
+  },
+
+  requestPendingState: async () => {
+    if (!inputChannel || get().state !== 'connected') {
+      return;
+    }
+
+    const message: RealtimeMessage = {
+      type: 'status-request',
       timestamp: Date.now(),
       seq: ++seq,
     };

--- a/packages/shared/src/types/message.ts
+++ b/packages/shared/src/types/message.ts
@@ -42,6 +42,8 @@ export type RealtimeMessageType =
   | 'user-answer' // User's answer to a question
   | 'permission-request' // SDK is asking for tool permission
   | 'permission-response' // User's response to permission request
+  | 'request-queued' // Message was queued because Claude is still processing
+  | 'status-request' // Mobile requests current pending state (question/permission)
   | 'complete'; // Claude has finished responding (query complete)
 
 export type InteractiveCommandType =
@@ -107,7 +109,7 @@ export interface RealtimeMessage {
   userAnswer?: UserAnswerData; // For user-answer type
   permissionRequest?: PermissionRequestData; // For permission-request type
   permissionResponse?: PermissionResponseData; // For permission-response type
-  errorCode?: string; // For error type messages (e.g., 'request_rejected', 'timeout')
+  errorCode?: string; // For error type messages (e.g., 'timeout')
   timestamp: number;
   seq: number;
 }


### PR DESCRIPTION
## Summary
- Messages sent while Claude is processing are now **queued** (last-one-wins) and auto-sent on completion, instead of being silently dropped
- Added `status-request` so mobile can recover missed `user-question`/`permission-request` broadcasts on reconnect
- Mobile typing indicator shows "Message queued, Claude is finishing up..." when a message is queued

## Test plan
- [ ] Send a message while Claude is still responding — should see "queued" indicator, then auto-process
- [ ] Disconnect and reconnect while a question/permission prompt is pending — should re-appear
- [ ] Run `npm test` in `apps/cli` — 262 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)