### PR TITLE
chore: Remove unused expo-haptics from all components

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -20,7 +20,6 @@
     "expo-clipboard": "^8.0.8",
     "expo-constants": "~18.0.13",
     "expo-file-system": "~19.0.21",
-    "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
     "expo-image-manipulator": "^14.0.8",
     "expo-image-picker": "^17.0.10",

--- a/apps/mobile/src/components/InputBar.tsx
+++ b/apps/mobile/src/components/InputBar.tsx
@@ -13,7 +13,6 @@ import {
   Text,
   ActivityIndicator,
 } from 'react-native';
-import * as Haptics from 'expo-haptics';
 import * as ImagePicker from 'expo-image-picker';
 import { useConnectionStore } from '../stores/connectionStore';
 import { convertImageToBase64 } from '../utils/imageUtils';
@@ -95,7 +94,6 @@ export function InputBar({ disabled }: InputBarProps) {
     }
 
     setIsSending(true);
-    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
 
     try {
       // Convert images to base64 attachments
@@ -171,8 +169,6 @@ export function InputBar({ disabled }: InputBarProps) {
   };
 
   const handleAttachment = async () => {
-    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-
     Alert.alert(
       'Add Attachment',
       'Choose an option',
@@ -230,7 +226,6 @@ export function InputBar({ disabled }: InputBarProps) {
             text: 'Clear',
             style: 'destructive',
             onPress: async () => {
-              await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
               // Clear local messages
               clearMessages();
               // Send clear request to CLI to reset Claude's session
@@ -269,13 +264,11 @@ export function InputBar({ disabled }: InputBarProps) {
 
   const handleResumeSessionSelect = async (selectedSessionId: string) => {
     setShowResumeSessionPicker(false);
-    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     // Send resume request (doesn't appear in chat)
     await sendResumeRequest(selectedSessionId);
   };
 
-  const handleCommandsPress = async () => {
-    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+  const handleCommandsPress = () => {
     setShowCommandPicker(true);
   };
 

--- a/apps/mobile/src/components/PermissionRequestPicker.tsx
+++ b/apps/mobile/src/components/PermissionRequestPicker.tsx
@@ -11,7 +11,6 @@ import {
   Platform,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import * as Haptics from 'expo-haptics';
 import type { PermissionRequestData } from 'termbridge-shared';
 
 interface PermissionRequestPickerProps {
@@ -33,13 +32,11 @@ export function PermissionRequestPicker({
   const isDark = colorScheme === 'dark';
   const insets = useSafeAreaInsets();
 
-  const handleAllow = async () => {
-    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+  const handleAllow = () => {
     onAllow();
   };
 
-  const handleDeny = async () => {
-    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+  const handleDeny = () => {
     onDeny('Permission denied by user');
   };
 

--- a/apps/mobile/src/components/SessionCard.tsx
+++ b/apps/mobile/src/components/SessionCard.tsx
@@ -10,7 +10,6 @@ import {
   ActivityIndicator,
 } from 'react-native';
 import { Swipeable } from 'react-native-gesture-handler';
-import * as Haptics from 'expo-haptics';
 import { useRouter } from 'expo-router';
 import type { Session } from 'termbridge-shared';
 import { useSessionStore } from '../stores/sessionStore';
@@ -58,9 +57,7 @@ export function SessionCard({ session }: SessionCardProps) {
   const isActive = session.status === 'active';
   const machineOnline = machine?.status === 'online';
 
-  const handleDisconnect = async () => {
-    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-
+  const handleDisconnect = () => {
     Alert.alert(
       'Disconnect Session',
       'Are you sure you want to disconnect this session? This will end the CLI session.',
@@ -84,9 +81,7 @@ export function SessionCard({ session }: SessionCardProps) {
     );
   };
 
-  const handleDelete = async () => {
-    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-
+  const handleDelete = () => {
     Alert.alert(
       'Delete Session',
       'Are you sure you want to delete this session? This action cannot be undone.',

--- a/apps/mobile/src/components/Terminal.tsx
+++ b/apps/mobile/src/components/Terminal.tsx
@@ -16,7 +16,6 @@ import {
 import { Image } from 'expo-image';
 import Markdown from 'react-native-markdown-display';
 import * as Clipboard from 'expo-clipboard';
-import * as Haptics from 'expo-haptics';
 import { useConnectionStore } from '../stores/connectionStore';
 import { useSessionStore } from '../stores/sessionStore';
 import type { RealtimeMessage, ToolUseData, ToolUseEditData, ToolUseWriteData, ToolUseGenericData } from 'termbridge-shared';
@@ -306,7 +305,6 @@ function MessageBubble({ message, isDark }: MessageBubbleProps) {
   // Copy full message to clipboard
   const handleCopy = useCallback(async () => {
     await Clipboard.setStringAsync(cleanContent);
-    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
     setShowActionMenu(false);
   }, [cleanContent]);
 
@@ -317,8 +315,7 @@ function MessageBubble({ message, isDark }: MessageBubbleProps) {
   }, []);
 
   // Long press handler to show action menu
-  const handleLongPress = useCallback(async () => {
-    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+  const handleLongPress = useCallback(() => {
     setShowActionMenu(true);
   }, []);
 
@@ -501,7 +498,6 @@ interface ClaudeMessageProps {
 
 function ClaudeMessage({ content, isDark }: ClaudeMessageProps) {
   const copyToClipboard = useCallback(async (text: string) => {
-    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
     await Clipboard.setStringAsync(text);
   }, []);
 

--- a/apps/mobile/src/components/UserQuestionPicker.tsx
+++ b/apps/mobile/src/components/UserQuestionPicker.tsx
@@ -12,7 +12,6 @@ import {
   Platform,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import * as Haptics from 'expo-haptics';
 import type { UserQuestionData } from 'termbridge-shared';
 
 interface UserQuestionPickerProps {
@@ -50,14 +49,12 @@ export function UserQuestionPicker({
     }
   }, [questionData]);
 
-  const handleOptionSelect = useCallback(async (questionIndex: number, optionLabel: string) => {
-    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+  const handleOptionSelect = useCallback((questionIndex: number, optionLabel: string) => {
     setSelectedOptions(prev => ({ ...prev, [questionIndex]: optionLabel }));
     setUsingOther(prev => ({ ...prev, [questionIndex]: false }));
   }, []);
 
-  const handleOtherSelect = useCallback(async (questionIndex: number) => {
-    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+  const handleOtherSelect = useCallback((questionIndex: number) => {
     setUsingOther(prev => ({ ...prev, [questionIndex]: true }));
     setSelectedOptions(prev => {
       const newSelected = { ...prev };
@@ -68,8 +65,6 @@ export function UserQuestionPicker({
 
   const handleSubmit = useCallback(async () => {
     if (!questionData) return;
-
-    await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
 
     // Build answers object
     const answers: Record<string, string> = {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,6 @@ importers:
       expo-file-system:
         specifier: ~19.0.21
         version: 19.0.21(expo@54.0.32)(react-native@0.81.5)
-      expo-haptics:
-        specifier: ~15.0.8
-        version: 15.0.8(expo@54.0.32)
       expo-image:
         specifier: ~3.0.11
         version: 3.0.11(expo@54.0.32)(react-native-web@0.21.2)(react-native@0.81.5)(react@19.1.0)
@@ -4545,14 +4542,6 @@ packages:
       fontfaceobserver: 2.3.0
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.1.0)
-    dev: false
-
-  /expo-haptics@15.0.8(expo@54.0.32):
-    resolution: {integrity: sha512-lftutojy8Qs8zaDzzjwM3gKHFZ8bOOEZDCkmh2Ddpe95Ra6kt2izeOfOfKuP/QEh0MZ1j9TfqippyHdRd1ZM9g==}
-    peerDependencies:
-      expo: '*'
-    dependencies:
-      expo: 54.0.32(@babel/core@7.28.6)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5)(react@19.1.0)
     dev: false
 
   /expo-image-loader@6.0.0(expo@54.0.32):


### PR DESCRIPTION
## Summary
- Remove all `expo-haptics` imports and calls from 5 components — haptic feedback was not working on device
- Affected files: InputBar, Terminal, SessionCard, PermissionRequestPicker, UserQuestionPicker

## Test plan
- [ ] Verify all button interactions still work without haptics (send, attachment, commands, copy, long-press, allow/deny, submit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)