### PR TITLE
feat: Status-response and typing indicator on reconnect

### DIFF
--- a/apps/cli/src/__tests__/client.test.ts
+++ b/apps/cli/src/__tests__/client.test.ts
@@ -615,6 +615,50 @@ describe('RealtimeClient', () => {
     });
   });
 
+  describe('broadcastStatusResponse', () => {
+    it('should send message with type status-response', async () => {
+      const client = new RealtimeClient({
+        supabase: mockSupabase as SupabaseClient,
+        sessionId: 'test-session-123',
+      });
+
+      await client.connect();
+      await client.broadcastStatusResponse(true, false);
+
+      expect(mockOutputChannel.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'broadcast',
+          event: 'output',
+          payload: expect.objectContaining({
+            type: 'status-response',
+            isProcessing: true,
+            isMessageQueued: false,
+          }),
+        })
+      );
+    });
+
+    it('should include both processing and queued flags', async () => {
+      const client = new RealtimeClient({
+        supabase: mockSupabase as SupabaseClient,
+        sessionId: 'test-session-123',
+      });
+
+      await client.connect();
+      await client.broadcastStatusResponse(false, true);
+
+      expect(mockOutputChannel.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            type: 'status-response',
+            isProcessing: false,
+            isMessageQueued: true,
+          }),
+        })
+      );
+    });
+  });
+
   describe('broadcastSystem', () => {
     it('should send message with type system', async () => {
       const client = new RealtimeClient({

--- a/apps/cli/src/__tests__/daemon.test.ts
+++ b/apps/cli/src/__tests__/daemon.test.ts
@@ -1384,6 +1384,163 @@ describe('Daemon', () => {
       });
     });
 
+    it('should broadcast status-response with processing state on status-request', async () => {
+      let inputHandler: ((payload: any) => void) | null = null;
+
+      mockInputChannel.on = vi.fn((event, filter, handler) => {
+        if (event === 'broadcast' && filter.event === 'input') {
+          inputHandler = handler;
+        }
+        return mockInputChannel as RealtimeChannel;
+      });
+
+      daemon = new Daemon({
+        cwd: '/test',
+        supabase: mockSupabase as SupabaseClient,
+        sessionId: 'session-789',
+      });
+
+      await daemon.start();
+
+      const sdkSession = (daemon as any).sdkSession;
+
+      // Simulate actively processing with no pending question/permission
+      vi.spyOn(sdkSession, 'isActive').mockReturnValue(true);
+      vi.spyOn(sdkSession, 'getPendingQuestionData').mockReturnValue(null);
+      vi.spyOn(sdkSession, 'getPendingPermissionData').mockReturnValue(null);
+      vi.spyOn(sdkSession, 'hasPendingPrompt').mockReturnValue(false);
+
+      const sendSpy = mockOutputChannel.send;
+
+      if (inputHandler) {
+        inputHandler({
+          payload: {
+            type: 'status-request',
+            timestamp: Date.now(),
+            seq: 1,
+          },
+        });
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(sendSpy).toHaveBeenCalledWith({
+        type: 'broadcast',
+        event: 'output',
+        payload: expect.objectContaining({
+          type: 'status-response',
+          isProcessing: true,
+          isMessageQueued: false,
+        }),
+      });
+    });
+
+    it('should broadcast isProcessing=false when idle on status-request', async () => {
+      let inputHandler: ((payload: any) => void) | null = null;
+
+      mockInputChannel.on = vi.fn((event, filter, handler) => {
+        if (event === 'broadcast' && filter.event === 'input') {
+          inputHandler = handler;
+        }
+        return mockInputChannel as RealtimeChannel;
+      });
+
+      daemon = new Daemon({
+        cwd: '/test',
+        supabase: mockSupabase as SupabaseClient,
+        sessionId: 'session-789',
+      });
+
+      await daemon.start();
+
+      const sdkSession = (daemon as any).sdkSession;
+
+      vi.spyOn(sdkSession, 'isActive').mockReturnValue(false);
+      vi.spyOn(sdkSession, 'getPendingQuestionData').mockReturnValue(null);
+      vi.spyOn(sdkSession, 'getPendingPermissionData').mockReturnValue(null);
+      vi.spyOn(sdkSession, 'hasPendingPrompt').mockReturnValue(false);
+
+      const sendSpy = mockOutputChannel.send;
+
+      if (inputHandler) {
+        inputHandler({
+          payload: {
+            type: 'status-request',
+            timestamp: Date.now(),
+            seq: 1,
+          },
+        });
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(sendSpy).toHaveBeenCalledWith({
+        type: 'broadcast',
+        event: 'output',
+        payload: expect.objectContaining({
+          type: 'status-response',
+          isProcessing: false,
+          isMessageQueued: false,
+        }),
+      });
+    });
+
+    it('should not report isProcessing when blocked on pending question', async () => {
+      let inputHandler: ((payload: any) => void) | null = null;
+
+      mockInputChannel.on = vi.fn((event, filter, handler) => {
+        if (event === 'broadcast' && filter.event === 'input') {
+          inputHandler = handler;
+        }
+        return mockInputChannel as RealtimeChannel;
+      });
+
+      daemon = new Daemon({
+        cwd: '/test',
+        supabase: mockSupabase as SupabaseClient,
+        sessionId: 'session-789',
+      });
+
+      await daemon.start();
+
+      const sdkSession = (daemon as any).sdkSession;
+
+      // Processing is true but there's a pending question — isActivelyWorking should be false
+      const mockQuestion = {
+        toolUseId: 'tool-123',
+        questions: [{ question: 'Pick?', header: 'Q', options: [{ label: 'A', description: 'opt' }] }],
+      };
+      vi.spyOn(sdkSession, 'isActive').mockReturnValue(true);
+      vi.spyOn(sdkSession, 'getPendingQuestionData').mockReturnValue(mockQuestion);
+      vi.spyOn(sdkSession, 'getPendingPermissionData').mockReturnValue(null);
+      vi.spyOn(sdkSession, 'hasPendingPrompt').mockReturnValue(false);
+
+      const sendSpy = mockOutputChannel.send;
+
+      if (inputHandler) {
+        inputHandler({
+          payload: {
+            type: 'status-request',
+            timestamp: Date.now(),
+            seq: 1,
+          },
+        });
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      // isProcessing should be false because the pending question takes priority
+      expect(sendSpy).toHaveBeenCalledWith({
+        type: 'broadcast',
+        event: 'output',
+        payload: expect.objectContaining({
+          type: 'status-response',
+          isProcessing: false,
+          isMessageQueued: false,
+        }),
+      });
+    });
+
     it('should handle broadcast errors silently when queuing requests', async () => {
       // Mock output channel to throw error
       mockOutputChannel.send = vi.fn().mockRejectedValue(new Error('Broadcast failed'));

--- a/apps/cli/src/__tests__/sdk-session.test.ts
+++ b/apps/cli/src/__tests__/sdk-session.test.ts
@@ -634,6 +634,69 @@ describe('SdkSession', () => {
       expect(queuedHandler).not.toHaveBeenCalled();
     });
 
+    it('should report hasPendingPrompt as false initially', () => {
+      expect(sdkSession.hasPendingPrompt()).toBe(false);
+    });
+
+    it('should report hasPendingPrompt as true when a message is queued', async () => {
+      let resolveStream: (() => void) | null = null;
+      const slowSession = {
+        get sessionId() { return 'slow-session'; },
+        send: vi.fn().mockResolvedValue(undefined),
+        stream: async function* () {
+          yield { type: 'system', subtype: 'init', session_id: 'slow-session' };
+          await new Promise<void>(r => { resolveStream = r; });
+          yield { type: 'result', subtype: 'success', result: 'done' };
+        },
+        close: vi.fn(),
+        [Symbol.asyncDispose]: async () => {},
+      };
+      mockedCreateSession.mockReturnValue(slowSession as any);
+
+      const firstPromise = sdkSession.sendPrompt('First');
+      await tick();
+
+      // Queue a second message while processing
+      await sdkSession.sendPrompt('Second');
+
+      expect(sdkSession.hasPendingPrompt()).toBe(true);
+
+      // Clean up
+      if (resolveStream) resolveStream();
+      await firstPromise;
+      await tick();
+    });
+
+    it('should report hasPendingPrompt as false after queued message is consumed', async () => {
+      let resolveStream: (() => void) | null = null;
+      const slowSession = {
+        get sessionId() { return 'slow-session'; },
+        send: vi.fn().mockResolvedValue(undefined),
+        stream: async function* () {
+          yield { type: 'system', subtype: 'init', session_id: 'slow-session' };
+          await new Promise<void>(r => { resolveStream = r; });
+          yield { type: 'result', subtype: 'success', result: 'done' };
+        },
+        close: vi.fn(),
+        [Symbol.asyncDispose]: async () => {},
+      };
+      mockedCreateSession.mockReturnValue(slowSession as any);
+
+      const firstPromise = sdkSession.sendPrompt('First');
+      await tick();
+
+      await sdkSession.sendPrompt('Second');
+      expect(sdkSession.hasPendingPrompt()).toBe(true);
+
+      // Complete first request — queued message should be consumed
+      if (resolveStream) resolveStream();
+      await firstPromise;
+      await tick();
+      await tick();
+
+      expect(sdkSession.hasPendingPrompt()).toBe(false);
+    });
+
     it('should suppress complete event when queued message exists', async () => {
       let resolveStream: (() => void) | null = null;
       const slowSession = {

--- a/apps/cli/src/daemon/daemon.ts
+++ b/apps/cli/src/daemon/daemon.ts
@@ -314,7 +314,8 @@ export class Daemon extends EventEmitter {
         return;
       }
 
-      // Handle status request - re-broadcast any pending question or permission
+      // Handle status request - re-broadcast any pending question or permission,
+      // then report current processing state so mobile can restore isTyping
       if (message.type === 'status-request') {
         if (this.realtimeClient) {
           try {
@@ -326,6 +327,13 @@ export class Daemon extends EventEmitter {
             if (pendingPermission) {
               await this.realtimeClient.broadcastPermissionRequest(pendingPermission);
             }
+
+            // Broadcast processing state last so it doesn't flash typing indicator
+            // before a pending question/permission modal appears
+            const isProcessing = this.sdkSession.isActive();
+            const isActivelyWorking = isProcessing && !pendingQuestion && !pendingPermission;
+            const isMessageQueued = this.sdkSession.hasPendingPrompt();
+            await this.realtimeClient.broadcastStatusResponse(isActivelyWorking, isMessageQueued);
           } catch {
             // Silently handle broadcast errors
           }

--- a/apps/cli/src/daemon/sdk-session.ts
+++ b/apps/cli/src/daemon/sdk-session.ts
@@ -646,6 +646,10 @@ export class SdkSession extends EventEmitter {
     return this.pendingPermissionData;
   }
 
+  hasPendingPrompt(): boolean {
+    return this.pendingPrompt !== null;
+  }
+
   async setModel(model: string): Promise<void> {
     if (model === this.currentModel) return;
 

--- a/apps/cli/src/realtime/client.ts
+++ b/apps/cli/src/realtime/client.ts
@@ -481,6 +481,32 @@ export class RealtimeClient extends EventEmitter {
     this.emit('broadcast', message);
   }
 
+  async broadcastStatusResponse(isProcessing: boolean, isMessageQueued: boolean): Promise<void> {
+    if (!this.outputChannel) {
+      throw new Error('Not connected');
+    }
+
+    if (!this.realtimeEnabled) {
+      return;
+    }
+
+    const message: RealtimeMessage = {
+      type: 'status-response',
+      isProcessing,
+      isMessageQueued,
+      timestamp: Date.now(),
+      seq: ++this.seq,
+    };
+
+    await this.outputChannel.send({
+      type: 'broadcast',
+      event: 'output',
+      payload: message,
+    });
+
+    this.emit('broadcast', message);
+  }
+
   async broadcastComplete(): Promise<void> {
     if (!this.outputChannel) {
       throw new Error('Not connected');

--- a/apps/mobile/src/stores/connectionStore.ts
+++ b/apps/mobile/src/stores/connectionStore.ts
@@ -175,7 +175,10 @@ export const useConnectionStore = create<ConnectionStoreState>((set, get) => ({
         const lastSeq = historicalMessages[historicalMessages.length - 1].seq;
         // Initialize seq counter to continue from where historical messages left off
         seq = lastSeq;
-        set({ messages, lastSeq });
+        // If the last message is user input, Claude is likely still processing — show typing
+        const lastMsg = historicalMessages[historicalMessages.length - 1];
+        const isLikelyProcessing = lastMsg.type === 'input';
+        set({ messages, lastSeq, isTyping: isLikelyProcessing });
       } else {
         // Reset seq counter for new session with no history
         seq = 0;
@@ -195,7 +198,6 @@ export const useConnectionStore = create<ConnectionStoreState>((set, get) => ({
 
       outputChannel.on('broadcast', { event: 'output' }, (payload) => {
         const message = payload.payload as RealtimeMessage;
-
         // Handle request-queued - message was queued because Claude is still processing
         if (message.type === 'request-queued') {
           set({ isMessageQueued: true });
@@ -283,6 +285,15 @@ export const useConnectionStore = create<ConnectionStoreState>((set, get) => ({
               ),
             }));
           }
+          return;
+        }
+
+        // Handle status-response - restore processing state on reconnect
+        if (message.type === 'status-response') {
+          set({
+            isTyping: message.isProcessing ?? false,
+            isMessageQueued: message.isMessageQueued ?? false,
+          });
           return;
         }
 

--- a/packages/shared/src/types/message.ts
+++ b/packages/shared/src/types/message.ts
@@ -45,6 +45,7 @@ export type RealtimeMessageType =
   | 'permission-response' // User's response to permission request
   | 'request-queued' // Message was queued because Claude is still processing
   | 'status-request' // Mobile requests current pending state (question/permission)
+  | 'status-response' // CLI responds with current processing state
   | 'session-title' // Session title was auto-generated from first user message
   | 'tool-use' // Tool use data for displaying diffs (Edit, Write, etc.)
   | 'complete'; // Claude has finished responding (query complete)
@@ -114,6 +115,8 @@ export interface RealtimeMessage {
   permissionRequest?: PermissionRequestData; // For permission-request type
   permissionResponse?: PermissionResponseData; // For permission-response type
   errorCode?: string; // For error type messages (e.g., 'timeout')
+  isProcessing?: boolean; // For status-response: whether Claude is actively working
+  isMessageQueued?: boolean; // For status-response: whether a queued message is pending
   toolUseData?: ToolUseData; // For tool-use type messages (diffs, file operations)
   timestamp: number;
   seq: number;


### PR DESCRIPTION
## Summary
- Add `status-response` broadcast: CLI reports current processing state (`isProcessing`, `isMessageQueued`) when mobile sends `status-request` on reconnect
- Add `hasPendingPrompt()` accessor to `SdkSession` for queued message visibility
- Infer `isTyping` from DB history on reconnect — if last persisted message is user input, show typing indicator immediately before realtime channel subscribes
- The two mechanisms complement each other: DB-history provides instant UI feedback, status-response provides authoritative correction

## Test plan
- [x] 314 CLI tests pass (`pnpm --filter @tongil_kim/clautunnel test`)
- [ ] Manual: start session, send prompt, navigate away and back while Claude is processing — typing indicator should appear immediately
- [ ] Manual: verify typing indicator clears when Claude completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)