### PR TITLE
fix: Persist Supabase session tokens after refresh

### DIFF
--- a/apps/cli/src/__tests__/commands-auth.test.ts
+++ b/apps/cli/src/__tests__/commands-auth.test.ts
@@ -44,10 +44,15 @@ const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
 // Mock @supabase/supabase-js
 const mockSetSession = vi.fn();
 const mockGetUser = vi.fn();
+const mockUnsubscribe = vi.fn();
+const mockOnAuthStateChange = vi.fn().mockReturnValue({
+  data: { subscription: { unsubscribe: mockUnsubscribe } },
+});
 const mockSupabaseClient = {
   auth: {
     setSession: mockSetSession,
     getUser: mockGetUser,
+    onAuthStateChange: mockOnAuthStateChange,
   },
   channel: vi.fn(() => ({
     on: vi.fn().mockReturnThis(),
@@ -124,7 +129,15 @@ describe('Command Authentication', () => {
       );
 
       // Mock successful session restoration
-      mockSetSession.mockResolvedValue({ error: null });
+      mockSetSession.mockResolvedValue({
+        data: {
+          session: {
+            access_token: 'test-access-token',
+            refresh_token: 'test-refresh-token',
+          },
+        },
+        error: null,
+      });
       mockGetUser.mockResolvedValue({
         data: { user: { id: 'user-123', email: 'test@example.com' } },
         error: null,
@@ -174,6 +187,7 @@ describe('Command Authentication', () => {
 
       // Mock session expiration
       mockSetSession.mockResolvedValue({
+        data: { session: null },
         error: { message: 'Invalid refresh token' },
       });
 
@@ -225,7 +239,15 @@ describe('Command Authentication', () => {
         })
       );
 
-      mockSetSession.mockResolvedValue({ error: null });
+      mockSetSession.mockResolvedValue({
+        data: {
+          session: {
+            access_token: 'valid-access-token',
+            refresh_token: 'valid-refresh-token',
+          },
+        },
+        error: null,
+      });
       mockGetUser.mockResolvedValue({
         data: { user: { id: 'user-123', email: 'test@example.com' } },
         error: null,

--- a/apps/cli/src/__tests__/restore-session.test.ts
+++ b/apps/cli/src/__tests__/restore-session.test.ts
@@ -17,6 +17,7 @@ describe('restoreSession', () => {
 
     mockConfig = {
       getSessionTokens: vi.fn(),
+      setSessionTokens: vi.fn(),
       clearSessionTokens: vi.fn(),
     };
   });
@@ -36,6 +37,7 @@ describe('restoreSession', () => {
       refreshToken: 'expired-refresh',
     });
     mockSupabase.auth.setSession.mockResolvedValue({
+      data: { session: null },
       error: new Error('Session expired'),
     });
 
@@ -50,7 +52,15 @@ describe('restoreSession', () => {
       accessToken: 'valid-token',
       refreshToken: 'valid-refresh',
     });
-    mockSupabase.auth.setSession.mockResolvedValue({ error: null });
+    mockSupabase.auth.setSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: 'valid-token',
+          refresh_token: 'valid-refresh',
+        },
+      },
+      error: null,
+    });
     mockSupabase.auth.getUser.mockResolvedValue({
       data: { user: null },
       error: new Error('Auth error'),
@@ -68,7 +78,15 @@ describe('restoreSession', () => {
       accessToken: 'valid-token',
       refreshToken: 'valid-refresh',
     });
-    mockSupabase.auth.setSession.mockResolvedValue({ error: null });
+    mockSupabase.auth.setSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: 'valid-token',
+          refresh_token: 'valid-refresh',
+        },
+      },
+      error: null,
+    });
     mockSupabase.auth.getUser.mockResolvedValue({
       data: { user: mockUser },
       error: null,
@@ -81,5 +99,84 @@ describe('restoreSession', () => {
       access_token: 'valid-token',
       refresh_token: 'valid-refresh',
     });
+  });
+
+  it('should persist refreshed tokens when setSession returns different tokens', async () => {
+    const mockUser = { id: 'user-123', email: 'test@example.com' };
+
+    mockConfig.getSessionTokens.mockReturnValue({
+      accessToken: 'old-access',
+      refreshToken: 'old-refresh',
+    });
+    mockSupabase.auth.setSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: 'new-access',
+          refresh_token: 'new-refresh',
+        },
+      },
+      error: null,
+    });
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: mockUser },
+      error: null,
+    });
+
+    const result = await restoreSession(mockSupabase, mockConfig);
+
+    expect(result).toEqual({ user: mockUser });
+    expect(mockConfig.setSessionTokens).toHaveBeenCalledWith({
+      accessToken: 'new-access',
+      refreshToken: 'new-refresh',
+    });
+  });
+
+  it('should NOT persist tokens when they are unchanged', async () => {
+    const mockUser = { id: 'user-123', email: 'test@example.com' };
+
+    mockConfig.getSessionTokens.mockReturnValue({
+      accessToken: 'same-token',
+      refreshToken: 'same-refresh',
+    });
+    mockSupabase.auth.setSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: 'same-token',
+          refresh_token: 'same-refresh',
+        },
+      },
+      error: null,
+    });
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: mockUser },
+      error: null,
+    });
+
+    const result = await restoreSession(mockSupabase, mockConfig);
+
+    expect(result).toEqual({ user: mockUser });
+    expect(mockConfig.setSessionTokens).not.toHaveBeenCalled();
+  });
+
+  it('should NOT persist tokens when setSession returns no session data', async () => {
+    const mockUser = { id: 'user-123', email: 'test@example.com' };
+
+    mockConfig.getSessionTokens.mockReturnValue({
+      accessToken: 'valid-token',
+      refreshToken: 'valid-refresh',
+    });
+    mockSupabase.auth.setSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: mockUser },
+      error: null,
+    });
+
+    const result = await restoreSession(mockSupabase, mockConfig);
+
+    expect(result).toEqual({ user: mockUser });
+    expect(mockConfig.setSessionTokens).not.toHaveBeenCalled();
   });
 });

--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -75,6 +75,19 @@ export function createStartCommand(): Command {
         }
 
         const { user } = session;
+
+        // Persist tokens when Supabase auto-refreshes during long-running sessions
+        const {
+          data: { subscription: authSubscription },
+        } = supabase.auth.onAuthStateChange((event, authSession) => {
+          if (event === 'TOKEN_REFRESHED' && authSession) {
+            config.setSessionTokens({
+              accessToken: authSession.access_token,
+              refreshToken: authSession.refresh_token,
+            });
+          }
+        });
+
         spinner.update(`Authenticated as ${user.email}...`);
 
         // Check Full Disk Access (macOS only)
@@ -234,6 +247,7 @@ export function createStartCommand(): Command {
               await machineClient.disconnect();
               machineClient = null;
             }
+            authSubscription.unsubscribe();
             console.log('[Cleanup] All sessions ended in database');
             await cleanup();
           } catch (error) {

--- a/apps/cli/src/utils/supabase.ts
+++ b/apps/cli/src/utils/supabase.ts
@@ -23,6 +23,7 @@ export function createSupabaseClient(
 
 export interface SessionTokenStore {
   getSessionTokens(): { accessToken: string; refreshToken: string } | null;
+  setSessionTokens(tokens: { accessToken: string; refreshToken: string }): void;
   clearSessionTokens(): void;
 }
 
@@ -35,14 +36,30 @@ export async function restoreSession(
     return null;
   }
 
-  const { error: sessionError } = await supabase.auth.setSession({
-    access_token: sessionTokens.accessToken,
-    refresh_token: sessionTokens.refreshToken,
-  });
+  const { data: sessionData, error: sessionError } =
+    await supabase.auth.setSession({
+      access_token: sessionTokens.accessToken,
+      refresh_token: sessionTokens.refreshToken,
+    });
 
   if (sessionError) {
     config.clearSessionTokens();
     return null;
+  }
+
+  // Persist refreshed tokens if Supabase rotated them
+  if (sessionData?.session) {
+    const newAccess = sessionData.session.access_token;
+    const newRefresh = sessionData.session.refresh_token;
+    if (
+      newAccess !== sessionTokens.accessToken ||
+      newRefresh !== sessionTokens.refreshToken
+    ) {
+      config.setSessionTokens({
+        accessToken: newAccess,
+        refreshToken: newRefresh,
+      });
+    }
   }
 
   const {


### PR DESCRIPTION
## Summary
- Supabase rotates refresh tokens on use, but new tokens were never saved back to `config.json` — causing forced re-login after restarting `clautunnel start`
- `restoreSession()` now captures and persists refreshed tokens from `setSession()` when they differ from stored values
- Registers `onAuthStateChange` listener for `TOKEN_REFRESHED` events during long-running daemon sessions, with clean unsubscribe on shutdown

## Test plan
- [x] All 317 existing tests pass
- [x] 3 new unit tests for token persistence scenarios (changed, unchanged, no session data)
- [x] Build succeeds cleanly
- [ ] Manual: `clautunnel login` → `clautunnel start` → stop → `clautunnel start` again → should authenticate without re-login

🤖 Generated with [Claude Code](https://claude.com/claude-code)