### PR TITLE
test(e2e): add more maestro edge case flows

### DIFF
--- a/apps/mobile/.maestro/flows/auth/login-email-case-insensitive.yaml
+++ b/apps/mobile/.maestro/flows/auth/login-email-case-insensitive.yaml
@@ -1,0 +1,20 @@
+appId: com.clautunnel.app
+---
+- launchApp:
+    clearState: true
+- assertVisible: "ClauTunnel"
+- tapOn:
+    id: "login-email-input"
+- inputText: "TEST@CLAUTUNNEL.COM"
+- tapOn:
+    id: "login-password-input"
+- inputText: "password123"
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "sessions-stats-total"
+    timeout: 5000
+- assertVisible: "Test MacBook"
+- assertVisible:
+    id: "session-card-test-session-1"

--- a/apps/mobile/.maestro/flows/session-detail/command-search-advanced.yaml
+++ b/apps/mobile/.maestro/flows/session-detail/command-search-advanced.yaml
@@ -1,0 +1,53 @@
+appId: com.clautunnel.app
+---
+- launchApp:
+    clearState: true
+- tapOn:
+    id: "login-email-input"
+- inputText: "test@clautunnel.com"
+- tapOn:
+    id: "login-password-input"
+- inputText: "password123"
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "session-card-test-session-1"
+    timeout: 5000
+- tapOn:
+    id: "session-card-test-session-1"
+
+# Open command picker
+- tapOn:
+    id: "input-commands-button"
+- extendedWaitUntil:
+    visible:
+      id: "command-picker-modal"
+    timeout: 3000
+
+# Leading slash should still match by command name
+- tapOn:
+    id: "command-search-input"
+- inputText: "/model"
+- assertVisible:
+    id: "command-option-model"
+- assertNotVisible:
+    id: "command-option-clear"
+
+# Description text should also match commands
+- clearText
+- inputText: "conversation"
+- assertVisible:
+    id: "command-option-clear"
+- assertNotVisible:
+    id: "command-option-model"
+
+- clearText
+- inputText: "previous"
+- assertVisible:
+    id: "command-option-resume"
+- assertNotVisible:
+    id: "command-option-clear"
+
+- tapOn:
+    id: "session-back-button"

--- a/apps/mobile/.maestro/flows/session-detail/permission-cancel.yaml
+++ b/apps/mobile/.maestro/flows/session-detail/permission-cancel.yaml
@@ -1,0 +1,38 @@
+appId: com.clautunnel.app
+---
+- launchApp:
+    clearState: true
+- tapOn:
+    id: "login-email-input"
+- inputText: "test@clautunnel.com"
+- tapOn:
+    id: "login-password-input"
+- inputText: "password123"
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "session-card-test-session-1"
+    timeout: 5000
+- tapOn:
+    id: "session-card-test-session-1"
+
+# Trigger permission request via test mode panel
+- tapOn:
+    id: "test-mode-toggle"
+- tapOn:
+    id: "test-mode-trigger-permission"
+- assertVisible:
+    id: "permission-request-modal"
+- assertVisible: "Permission Required"
+- assertVisible: "Bash"
+
+# Cancel without making a decision
+- tapOn: "Cancel"
+- assertNotVisible:
+    id: "permission-request-modal"
+- assertNotVisible: "Permission allowed for Bash"
+- assertNotVisible: "Permission denied for Bash"
+
+- tapOn:
+    id: "session-back-button"

--- a/apps/mobile/.maestro/flows/session-detail/user-question-submit-disabled.yaml
+++ b/apps/mobile/.maestro/flows/session-detail/user-question-submit-disabled.yaml
@@ -1,0 +1,51 @@
+appId: com.clautunnel.app
+---
+- launchApp:
+    clearState: true
+- tapOn:
+    id: "login-email-input"
+- inputText: "test@clautunnel.com"
+- tapOn:
+    id: "login-password-input"
+- inputText: "password123"
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "session-card-test-session-1"
+    timeout: 5000
+- tapOn:
+    id: "session-card-test-session-1"
+
+# Trigger user question via test mode panel
+- tapOn:
+    id: "test-mode-toggle"
+- tapOn:
+    id: "test-mode-trigger-question"
+- assertVisible:
+    id: "user-question-modal"
+- assertVisible: "Which testing framework should we use?"
+
+# Submit should stay disabled until an answer is provided
+- tapOn:
+    id: "user-question-submit"
+- assertVisible:
+    id: "user-question-modal"
+- assertNotVisible: "Question answered"
+
+# "Other" without text should also stay incomplete
+- tapOn:
+    id: "user-question-other-0"
+- tapOn:
+    id: "user-question-submit"
+- assertVisible:
+    id: "user-question-modal"
+- assertNotVisible: "Question answered"
+
+- tapOn:
+    id: "user-question-cancel"
+- assertNotVisible:
+    id: "user-question-modal"
+
+- tapOn:
+    id: "session-back-button"


### PR DESCRIPTION
## Summary
- add a login flow for case-insensitive email handling in test mode
- add advanced command search coverage for slash-prefixed and description-based queries
- add a permission cancel flow to verify closing without a decision
- add a user question flow to verify submit stays disabled until an answer is provided

## Testing
- YAML syntax checked locally
- Maestro not run locally