### PR TITLE
test(e2e): stabilize android smoke startup

### DIFF
--- a/apps/mobile/.maestro/flows/smoke.yaml
+++ b/apps/mobile/.maestro/flows/smoke.yaml
@@ -3,7 +3,11 @@ appId: com.clautunnel.app
 - launchApp:
     clearState: true
 
-# Take debug screenshot to see initial state
+# Wait for the login screen to finish rendering, especially on Android cold starts
+- extendedWaitUntil:
+    visible:
+      id: "login-email-input"
+    timeout: 15000
 - takeScreenshot: app-launched
 
 # Sign in with mock credentials


### PR DESCRIPTION
## Summary
- wait for the login form to render before asserting the title in the smoke flow
- keep the debug screenshot after the login screen is actually visible

## Why
Android cold starts can briefly show a blank screen before the auth UI renders, which makes the current smoke test flaky.

## Testing
- YAML syntax checked locally
- Maestro not run locally