### PR TITLE
test(e2e): stabilize android smoke startup for PR #33

### DIFF
--- a/apps/mobile/.maestro/flows/smoke.yaml
+++ b/apps/mobile/.maestro/flows/smoke.yaml
@@ -3,7 +3,11 @@ appId: com.clautunnel.app
 - launchApp:
     clearState: true
 
-# Take debug screenshot to see initial state
+# Wait for the login screen to finish rendering, especially on Android cold starts
+- extendedWaitUntil:
+    visible:
+      id: "login-email-input"
+    timeout: 15000
 - takeScreenshot: app-launched
 
 # Sign in with mock credentials


### PR DESCRIPTION
## Summary
- apply the Android smoke startup wait fix on top of #33
- wait for the login form to render before asserting the title text

## Why
PR #33 is failing in  before the login screen finishes rendering.

## Note
This PR targets  directly so it can be merged into #33 and retrigger CI.