### PR TITLE
test(e2e): add more maestro edge-case flows

### DIFF
--- a/apps/mobile/.maestro/flows/auth/login-error-dismiss.yaml
+++ b/apps/mobile/.maestro/flows/auth/login-error-dismiss.yaml
@@ -1,0 +1,22 @@
+appId: com.clautunnel.app
+---
+- launchApp:
+    clearState: true
+- tapOn:
+    id: "login-email-input"
+- inputText: "bad@example.com"
+- tapOn:
+    id: "login-password-input"
+- inputText: "wrongpassword"
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "login-error-text"
+    timeout: 3000
+- assertVisible: "Invalid email or password"
+- tapOn: "Dismiss"
+- assertNotVisible:
+    id: "login-error-text"
+- assertVisible:
+    id: "login-button"

--- a/apps/mobile/.maestro/flows/auth/register-login-navigation.yaml
+++ b/apps/mobile/.maestro/flows/auth/register-login-navigation.yaml
@@ -1,0 +1,18 @@
+appId: com.clautunnel.app
+---
+- launchApp:
+    clearState: true
+- tapOn:
+    id: "login-signup-link"
+- extendedWaitUntil:
+    visible:
+      id: "register-button"
+    timeout: 3000
+- assertVisible: "Create Account"
+- tapOn:
+    id: "register-login-link"
+- extendedWaitUntil:
+    visible:
+      id: "login-button"
+    timeout: 3000
+- assertVisible: "ClauTunnel"

--- a/apps/mobile/.maestro/flows/session-detail/clear-conversation-cancel.yaml
+++ b/apps/mobile/.maestro/flows/session-detail/clear-conversation-cancel.yaml
@@ -1,0 +1,31 @@
+appId: com.clautunnel.app
+---
+- launchApp:
+    clearState: true
+- tapOn:
+    id: "login-email-input"
+- inputText: "test@clautunnel.com"
+- tapOn:
+    id: "login-password-input"
+- inputText: "password123"
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "session-card-test-session-1"
+    timeout: 5000
+- tapOn:
+    id: "session-card-test-session-1"
+- assertVisible: "Hello! How can I help you today?"
+- tapOn:
+    id: "input-commands-button"
+- extendedWaitUntil:
+    visible: "command-clear"
+    timeout: 3000
+- tapOn: "command-clear"
+- assertVisible: "Clear Conversation"
+- tapOn: "Cancel"
+- assertNotVisible: "Clear Conversation"
+- assertVisible: "Hello! How can I help you today?"
+- tapOn:
+    id: "session-back-button"

--- a/apps/mobile/.maestro/flows/session-detail/model-picker-cancel.yaml
+++ b/apps/mobile/.maestro/flows/session-detail/model-picker-cancel.yaml
@@ -1,0 +1,33 @@
+appId: com.clautunnel.app
+---
+- launchApp:
+    clearState: true
+- tapOn:
+    id: "login-email-input"
+- inputText: "test@clautunnel.com"
+- tapOn:
+    id: "login-password-input"
+- inputText: "password123"
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "session-card-test-session-1"
+    timeout: 5000
+- tapOn:
+    id: "session-card-test-session-1"
+- assertVisible: "Opus 4.6"
+- tapOn:
+    id: "input-commands-button"
+- extendedWaitUntil:
+    visible: "command-model"
+    timeout: 3000
+- tapOn: "command-model"
+- extendedWaitUntil:
+    visible: "Select Model"
+    timeout: 3000
+- tapOn: "Cancel"
+- assertNotVisible: "Select Model"
+- assertVisible: "Opus 4.6"
+- tapOn:
+    id: "session-back-button"

--- a/apps/mobile/.maestro/flows/settings/logout-cancel.yaml
+++ b/apps/mobile/.maestro/flows/settings/logout-cancel.yaml
@@ -1,0 +1,30 @@
+appId: com.clautunnel.app
+---
+- launchApp:
+    clearState: true
+- tapOn:
+    id: "login-email-input"
+- inputText: "test@clautunnel.com"
+- tapOn:
+    id: "login-password-input"
+- inputText: "password123"
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "sessions-stats-total"
+    timeout: 5000
+- tapOn:
+    point: "75%,93%"
+- extendedWaitUntil:
+    visible:
+      id: "settings-logout-button"
+    timeout: 5000
+- tapOn:
+    id: "settings-logout-button"
+- assertVisible: "Sign Out"
+- tapOn: "Cancel"
+- assertVisible:
+    id: "settings-logout-button"
+- assertVisible:
+    id: "settings-email"


### PR DESCRIPTION
## Summary
- add login error dismissal coverage after invalid credentials
- add register-to-login navigation coverage
- add cancel-path coverage for clear conversation, model picker, and logout

## Testing
- YAML syntax checked locally
- Maestro not run locally