### PR TITLE
fix(mobile): show ended session count on badge

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -26,6 +26,7 @@ interface MachineSection {
   data: any[];
   onlineCount: number;
   offlineCount: number;
+  endedCount: number;
   hasListener: boolean;
 }
 
@@ -100,6 +101,7 @@ export default function SessionsScreen() {
           data: [],
           onlineCount: 0,
           offlineCount: 0,
+          endedCount: 0,
           hasListener: !!machineOnlineStatus[machine.id],
         });
       }
@@ -119,6 +121,7 @@ export default function SessionsScreen() {
           data: [],
           onlineCount: 0,
           offlineCount: 0,
+          endedCount: 0,
           hasListener: !!machineOnlineStatus[machineId],
         });
       }
@@ -130,6 +133,9 @@ export default function SessionsScreen() {
         section.onlineCount++;
       } else {
         section.offlineCount++;
+      }
+      if (session.status === 'ended') {
+        section.endedCount++;
       }
     });
 
@@ -304,21 +310,21 @@ export default function SessionsScreen() {
                         <Text style={[styles.sectionBadgeText, isDark && styles.sectionBadgeTextDark]}>{section.onlineCount}</Text>
                       </View>
                     )}
-                    {section.offlineCount > 0 && (
+                    {section.endedCount > 0 && (
                       <View style={[styles.sectionBadge, styles.sectionBadgeOffline, isDark && styles.sectionBadgeOfflineDark]}>
                         <Text style={[styles.sectionBadgeText, styles.sectionBadgeTextOffline, isDark && styles.sectionBadgeTextOfflineDark]}>
-                          {section.offlineCount}
+                          {section.endedCount}
                         </Text>
                       </View>
                     )}
                   </View>
-                  {section.offlineCount > 0 && (
+                  {section.endedCount > 0 && (
                     <TouchableOpacity
                       testID={`machine-clear-ended-${section.id}`}
                       style={styles.sectionClearButton}
                       onPress={(e) => {
                         e.stopPropagation();
-                        onClearEndedForMachine(section.id, section.title, section.offlineCount);
+                        onClearEndedForMachine(section.id, section.title, section.endedCount);
                       }}
                       hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
                     >


### PR DESCRIPTION
## Summary
- The badge next to the trash icon was showing `offlineCount` (active-but-disconnected + ended sessions), while the delete action only removes `ended` sessions — causing a count mismatch
- Added `endedCount` field to `MachineSection` and updated the badge, trash icon visibility, and alert dialog to use it instead of `offlineCount`

## Test plan
- [ ] Verify badge shows correct count matching only ended sessions
- [ ] Verify trash icon only appears when there are ended sessions
- [ ] Verify alert dialog shows correct count
- [ ] Verify after deleting ended sessions, badge and trash icon disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)