### PR TITLE
fix: harden mobile bootstrap claims

### DIFF
--- a/apps/cli/src/__tests__/mobile-auth-bootstrap-crypto.test.ts
+++ b/apps/cli/src/__tests__/mobile-auth-bootstrap-crypto.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import { webcrypto } from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   decryptBootstrapRefreshToken,
   encryptBootstrapRefreshToken,
 } from '../../../../supabase/functions/mobile-auth-bootstrap/crypto.ts';
 
 describe('mobile auth bootstrap crypto', () => {
+  beforeEach(() => {
+    vi.stubGlobal('crypto', webcrypto);
+  });
+
   it('encrypts and decrypts refresh tokens without storing plaintext', async () => {
     const secret = 'test-bootstrap-secret';
     const refreshToken = 'refresh-token-value';

--- a/apps/cli/src/__tests__/mobile-auth-bootstrap-rate-limit.test.ts
+++ b/apps/cli/src/__tests__/mobile-auth-bootstrap-rate-limit.test.ts
@@ -1,0 +1,99 @@
+import { webcrypto } from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  takeBootstrapClaimRateLimit,
+  type BootstrapClaimRateLimitRecord,
+  type BootstrapClaimRateLimitStore,
+} from '../../../../supabase/functions/mobile-auth-bootstrap/rate-limit.ts';
+
+class InMemoryRateLimitStore implements BootstrapClaimRateLimitStore {
+  record: BootstrapClaimRateLimitRecord | null = null;
+  cleanupExpired = vi.fn(async () => {});
+
+  async get(keyHash: string) {
+    if (this.record?.keyHash === keyHash) {
+      return this.record;
+    }
+    return null;
+  }
+
+  async put(record: BootstrapClaimRateLimitRecord) {
+    this.record = record;
+  }
+}
+
+describe('mobile auth bootstrap claim rate limit', () => {
+  let store: InMemoryRateLimitStore;
+
+  beforeEach(() => {
+    store = new InMemoryRateLimitStore();
+    vi.stubGlobal('crypto', webcrypto);
+  });
+
+  it('allows claim attempts within the limit and increments the counter', async () => {
+    const now = new Date('2026-03-12T12:00:00.000Z');
+
+    const first = await takeBootstrapClaimRateLimit(store, {
+      clientKey: '203.0.113.5',
+      now,
+      maxAttempts: 3,
+      windowMs: 60_000,
+    });
+    const second = await takeBootstrapClaimRateLimit(store, {
+      clientKey: '203.0.113.5',
+      now: new Date('2026-03-12T12:00:10.000Z'),
+      maxAttempts: 3,
+      windowMs: 60_000,
+    });
+
+    expect(first.allowed).toBe(true);
+    expect(second.allowed).toBe(true);
+    expect(store.record?.attemptCount).toBe(2);
+    expect(store.cleanupExpired).toHaveBeenCalledTimes(2);
+  });
+
+  it('blocks claim attempts after the limit is reached', async () => {
+    const now = new Date('2026-03-12T12:00:00.000Z');
+
+    await takeBootstrapClaimRateLimit(store, {
+      clientKey: '203.0.113.5',
+      now,
+      maxAttempts: 2,
+      windowMs: 60_000,
+    });
+    await takeBootstrapClaimRateLimit(store, {
+      clientKey: '203.0.113.5',
+      now: new Date('2026-03-12T12:00:05.000Z'),
+      maxAttempts: 2,
+      windowMs: 60_000,
+    });
+    const third = await takeBootstrapClaimRateLimit(store, {
+      clientKey: '203.0.113.5',
+      now: new Date('2026-03-12T12:00:06.000Z'),
+      maxAttempts: 2,
+      windowMs: 60_000,
+    });
+
+    expect(third.allowed).toBe(false);
+    expect(third.retryAfterSec).toBeGreaterThan(0);
+    expect(store.record?.attemptCount).toBe(2);
+  });
+
+  it('starts a fresh window after the previous one expires', async () => {
+    await takeBootstrapClaimRateLimit(store, {
+      clientKey: '203.0.113.5',
+      now: new Date('2026-03-12T12:00:00.000Z'),
+      maxAttempts: 2,
+      windowMs: 60_000,
+    });
+    await takeBootstrapClaimRateLimit(store, {
+      clientKey: '203.0.113.5',
+      now: new Date('2026-03-12T12:01:30.000Z'),
+      maxAttempts: 2,
+      windowMs: 60_000,
+    });
+
+    expect(store.record?.attemptCount).toBe(1);
+    expect(store.record?.windowStartedAt).toBe('2026-03-12T12:01:30.000Z');
+  });
+});

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -39,15 +39,17 @@ export default function RootLayout() {
   useEffect(() => {
     if (isTestMode()) return;
 
-    let cancelled = false;
+    const controller = new AbortController();
 
     const handleAuth = async () => {
       const bootstrapCode = process.env.EXPO_PUBLIC_MOBILE_BOOTSTRAP_CODE;
       if (bootstrapCode) {
-        const success = await claimBootstrapCode(bootstrapCode);
+        const success = await claimBootstrapCode(bootstrapCode, {
+          signal: controller.signal,
+        });
         if (success) return;
       }
-      if (!cancelled) {
+      if (!controller.signal.aborted) {
         // No bootstrap code or claim failed — fall back to persisted session check
         void initialize();
       }
@@ -56,7 +58,7 @@ export default function RootLayout() {
     void handleAuth();
 
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [claimBootstrapCode, initialize]);
 

--- a/apps/mobile/src/__tests__/auth-store-bootstrap.test.ts
+++ b/apps/mobile/src/__tests__/auth-store-bootstrap.test.ts
@@ -127,4 +127,31 @@ describe('AuthStore bootstrap auth', () => {
     expect(unsubscribeSecond).not.toHaveBeenCalled();
     expect(mockOnAuthStateChange).toHaveBeenCalledTimes(2);
   });
+
+  it('does not continue into refresh auth when bootstrap claim is aborted mid-flight', async () => {
+    let resolveInvoke: ((value: unknown) => void) | null = null;
+    mockInvoke.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveInvoke = resolve;
+        })
+    );
+
+    const { useAuthStore } = await import('../stores/authStore');
+    const controller = new AbortController();
+
+    const pending = useAuthStore.getState().claimBootstrapCode('one-time-code', {
+      signal: controller.signal,
+    });
+    controller.abort();
+    resolveInvoke?.({
+      data: { refreshToken: 'server-refresh-token' },
+      error: null,
+    });
+
+    await expect(pending).resolves.toBe(false);
+    expect(mockRefreshSession).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().error).toBeNull();
+    expect(useAuthStore.getState().isLoading).toBe(false);
+  });
 });

--- a/apps/mobile/src/stores/authStore.ts
+++ b/apps/mobile/src/stores/authStore.ts
@@ -16,8 +16,8 @@ interface AuthState {
 
   // Actions
   initialize: () => Promise<void>;
-  claimBootstrapCode: (code: string) => Promise<boolean>;
-  signInWithToken: (refreshToken: string) => Promise<boolean>;
+  claimBootstrapCode: (code: string, options?: { signal?: AbortSignal }) => Promise<boolean>;
+  signInWithToken: (refreshToken: string, options?: { signal?: AbortSignal }) => Promise<boolean>;
   signIn: (email: string, password: string) => Promise<void>;
   signUp: (email: string, password: string) => Promise<void>;
   signOut: () => Promise<void>;
@@ -53,6 +53,10 @@ function getErrorMessage(error: unknown, fallback: string) {
     return error.message;
   }
   return fallback;
+}
+
+function isAbortError(error: unknown) {
+  return error instanceof Error && error.name === 'AbortError';
 }
 
 let _authSubscription: { unsubscribe: () => void } | null = null;
@@ -107,13 +111,22 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     }
   },
 
-  claimBootstrapCode: async (code: string) => {
+  claimBootstrapCode: async (code: string, options?: { signal?: AbortSignal }) => {
     try {
+      if (options?.signal?.aborted) {
+        return false;
+      }
+
       set({ isLoading: true, error: null });
 
       const { data, error } = await supabase.functions.invoke('mobile-auth-bootstrap', {
         body: { action: 'claim', code },
       });
+
+      if (options?.signal?.aborted) {
+        set({ isLoading: false });
+        return false;
+      }
 
       if (error) throw error;
 
@@ -124,8 +137,12 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         throw new Error('Bootstrap response missing refresh token');
       }
 
-      return await get().signInWithToken(refreshToken);
+      return await get().signInWithToken(refreshToken, options);
     } catch (error) {
+      if (isAbortError(error) || options?.signal?.aborted) {
+        set({ isLoading: false });
+        return false;
+      }
       set({
         error: getErrorMessage(error, 'Failed to claim bootstrap code'),
         isLoading: false,
@@ -134,13 +151,22 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     }
   },
 
-  signInWithToken: async (refreshToken: string) => {
+  signInWithToken: async (refreshToken: string, options?: { signal?: AbortSignal }) => {
     try {
+      if (options?.signal?.aborted) {
+        return false;
+      }
+
       set({ isLoading: true, error: null });
 
       const { data, error } = await supabase.auth.refreshSession({
         refresh_token: refreshToken,
       });
+
+      if (options?.signal?.aborted) {
+        set({ isLoading: false });
+        return false;
+      }
 
       if (error) throw error;
 
@@ -154,8 +180,12 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
       return true;
     } catch (error) {
+      if (isAbortError(error) || options?.signal?.aborted) {
+        set({ isLoading: false });
+        return false;
+      }
       set({
-        error: error instanceof Error ? error.message : 'Failed to authenticate',
+        error: getErrorMessage(error, 'Failed to authenticate'),
         isLoading: false,
       });
       return false;

--- a/supabase/functions/mobile-auth-bootstrap/index.ts
+++ b/supabase/functions/mobile-auth-bootstrap/index.ts
@@ -4,6 +4,10 @@ import {
   decryptBootstrapRefreshToken,
   encryptBootstrapRefreshToken,
 } from './crypto.ts';
+import {
+  takeBootstrapClaimRateLimit,
+  type BootstrapClaimRateLimitStore,
+} from './rate-limit.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,6 +16,8 @@ const corsHeaders = {
 };
 
 const BOOTSTRAP_TTL_MS = 300_000;
+const CLAIM_RATE_LIMIT_MAX_ATTEMPTS = 10;
+const CLAIM_RATE_LIMIT_WINDOW_MS = 300_000;
 
 function json(status: number, body: Record<string, unknown>) {
   return new Response(JSON.stringify(body), {
@@ -41,6 +47,18 @@ function getEnv(name: string) {
     throw new Error(`Missing required environment variable: ${name}`);
   }
   return value;
+}
+
+function getClientRateLimitKey(req: Request) {
+  const forwardedFor = req.headers.get('x-forwarded-for');
+  if (forwardedFor) {
+    return forwardedFor.split(',')[0]?.trim() || 'unknown';
+  }
+  const realIp = req.headers.get('x-real-ip');
+  if (realIp) return realIp.trim();
+  const cfConnectingIp = req.headers.get('cf-connecting-ip');
+  if (cfConnectingIp) return cfConnectingIp.trim();
+  return 'unknown';
 }
 
 serve(async (req) => {
@@ -126,6 +144,68 @@ serve(async (req) => {
       const code = typeof body.code === 'string' ? body.code.trim() : '';
       if (!code) {
         return json(400, { error: 'code is required' });
+      }
+
+      const rateLimitStore: BootstrapClaimRateLimitStore = {
+        async cleanupExpired(cutoffIso: string) {
+          await serviceClient
+            .from('mobile_auth_claim_rate_limits')
+            .delete()
+            .lt('window_started_at', cutoffIso);
+        },
+        async get(keyHash: string) {
+          const { data, error } = await serviceClient
+            .from('mobile_auth_claim_rate_limits')
+            .select('key_hash, attempt_count, window_started_at')
+            .eq('key_hash', keyHash)
+            .maybeSingle();
+
+          if (error || !data) {
+            return null;
+          }
+
+          return {
+            keyHash: data.key_hash,
+            attemptCount: data.attempt_count,
+            windowStartedAt: data.window_started_at,
+          };
+        },
+        async put(record) {
+          const { error } = await serviceClient
+            .from('mobile_auth_claim_rate_limits')
+            .upsert({
+              key_hash: record.keyHash,
+              attempt_count: record.attemptCount,
+              window_started_at: record.windowStartedAt,
+            });
+
+          if (error) {
+            throw new Error(error.message);
+          }
+        },
+      };
+
+      const rateLimit = await takeBootstrapClaimRateLimit(rateLimitStore, {
+        clientKey: getClientRateLimitKey(req),
+        now: new Date(),
+        maxAttempts: CLAIM_RATE_LIMIT_MAX_ATTEMPTS,
+        windowMs: CLAIM_RATE_LIMIT_WINDOW_MS,
+      });
+
+      if (!rateLimit.allowed) {
+        return new Response(
+          JSON.stringify({
+            error: 'Too many bootstrap claim attempts. Please wait and try again.',
+          }),
+          {
+            status: 429,
+            headers: {
+              ...corsHeaders,
+              'Content-Type': 'application/json',
+              'Retry-After': String(rateLimit.retryAfterSec ?? 60),
+            },
+          }
+        );
       }
 
       const codeHash = await sha256(code);

--- a/supabase/functions/mobile-auth-bootstrap/rate-limit.ts
+++ b/supabase/functions/mobile-auth-bootstrap/rate-limit.ts
@@ -1,0 +1,78 @@
+async function sha256(value: string) {
+  const data = new TextEncoder().encode(value);
+  const hash = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hash))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export interface BootstrapClaimRateLimitRecord {
+  keyHash: string;
+  attemptCount: number;
+  windowStartedAt: string;
+}
+
+export interface BootstrapClaimRateLimitStore {
+  cleanupExpired(cutoffIso: string): Promise<void>;
+  get(keyHash: string): Promise<BootstrapClaimRateLimitRecord | null>;
+  put(record: BootstrapClaimRateLimitRecord): Promise<void>;
+}
+
+export interface BootstrapClaimRateLimitParams {
+  clientKey: string;
+  now: Date;
+  maxAttempts: number;
+  windowMs: number;
+}
+
+export interface BootstrapClaimRateLimitResult {
+  allowed: boolean;
+  retryAfterSec?: number;
+}
+
+export async function takeBootstrapClaimRateLimit(
+  store: BootstrapClaimRateLimitStore,
+  { clientKey, now, maxAttempts, windowMs }: BootstrapClaimRateLimitParams
+): Promise<BootstrapClaimRateLimitResult> {
+  const keyHash = await sha256(clientKey);
+  const nowMs = now.getTime();
+  const cutoffMs = nowMs - windowMs;
+  const cutoffIso = new Date(cutoffMs).toISOString();
+
+  await store.cleanupExpired(cutoffIso);
+
+  const existing = await store.get(keyHash);
+  if (!existing) {
+    await store.put({
+      keyHash,
+      attemptCount: 1,
+      windowStartedAt: now.toISOString(),
+    });
+    return { allowed: true };
+  }
+
+  const windowStartedMs = new Date(existing.windowStartedAt).getTime();
+  if (windowStartedMs <= cutoffMs) {
+    await store.put({
+      keyHash,
+      attemptCount: 1,
+      windowStartedAt: now.toISOString(),
+    });
+    return { allowed: true };
+  }
+
+  if (existing.attemptCount >= maxAttempts) {
+    const retryAfterMs = Math.max(windowStartedMs + windowMs - nowMs, 0);
+    return {
+      allowed: false,
+      retryAfterSec: Math.ceil(retryAfterMs / 1000),
+    };
+  }
+
+  await store.put({
+    keyHash,
+    attemptCount: existing.attemptCount + 1,
+    windowStartedAt: existing.windowStartedAt,
+  });
+  return { allowed: true };
+}

--- a/supabase/migrations/007_add_mobile_auth_claim_rate_limits.sql
+++ b/supabase/migrations/007_add_mobile_auth_claim_rate_limits.sql
@@ -1,0 +1,22 @@
+CREATE TABLE mobile_auth_claim_rate_limits (
+  key_hash TEXT PRIMARY KEY,
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  window_started_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_mobile_auth_claim_rate_limits_window_started_at
+  ON mobile_auth_claim_rate_limits(window_started_at);
+
+ALTER TABLE mobile_auth_claim_rate_limits ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY mobile_auth_claim_rate_limits_no_access
+  ON mobile_auth_claim_rate_limits
+  FOR ALL
+  USING (false)
+  WITH CHECK (false);
+
+CREATE TRIGGER update_mobile_auth_claim_rate_limits_updated_at
+  BEFORE UPDATE ON mobile_auth_claim_rate_limits
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary
- add AbortController-aware bootstrap claim handling so unmounted startup flows stop before refresh auth continues
- add DB-backed rate limiting for bootstrap claim attempts and the supporting migration/helper
- cover the new hardening with bootstrap crypto, rate-limit, and auth-store tests

## Testing
- pnpm --filter @tongil_kim/clautunnel test -- src/__tests__/mobile-auth-bootstrap.test.ts src/__tests__/mobile-auth-bootstrap-crypto.test.ts src/__tests__/mobile-auth-bootstrap-rate-limit.test.ts src/__tests__/mobile-server.test.ts
- pnpm --filter @clautunnel/mobile test
- pnpm --filter clautunnel-shared build
- pnpm --filter @tongil_kim/clautunnel build