### PR TITLE
fix: restore mobile bootstrap auth with setSession

### DIFF
--- a/apps/cli/src/__tests__/mobile-auth-bootstrap.test.ts
+++ b/apps/cli/src/__tests__/mobile-auth-bootstrap.test.ts
@@ -37,6 +37,7 @@ describe('createMobileAuthBootstrap', () => {
         },
         body: JSON.stringify({
           action: 'create',
+          accessToken: 'access-token',
           refreshToken: 'refresh-token',
         }),
       }

--- a/apps/cli/src/utils/mobile-auth-bootstrap.ts
+++ b/apps/cli/src/utils/mobile-auth-bootstrap.ts
@@ -25,6 +25,7 @@ export async function createMobileAuthBootstrap({
     },
     body: JSON.stringify({
       action: 'create',
+      accessToken,
       refreshToken,
     }),
   });

--- a/apps/mobile/src/__tests__/auth-store-bootstrap.test.ts
+++ b/apps/mobile/src/__tests__/auth-store-bootstrap.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockGetSession = vi.fn();
 const mockOnAuthStateChange = vi.fn();
 const mockRefreshSession = vi.fn();
+const mockSetSession = vi.fn();
 const mockInvoke = vi.fn();
 
 vi.mock('../services/supabase', () => ({
@@ -11,6 +12,7 @@ vi.mock('../services/supabase', () => ({
       getSession: mockGetSession,
       onAuthStateChange: mockOnAuthStateChange,
       refreshSession: mockRefreshSession,
+      setSession: mockSetSession,
       signInWithPassword: vi.fn(),
       signUp: vi.fn(),
       signOut: vi.fn(),
@@ -52,10 +54,13 @@ describe('AuthStore bootstrap auth', () => {
 
   it('claims a bootstrap code and signs in with the returned refresh token', async () => {
     mockInvoke.mockResolvedValue({
-      data: { refreshToken: 'server-refresh-token' },
+      data: {
+        accessToken: 'server-access-token',
+        refreshToken: 'server-refresh-token',
+      },
       error: null,
     });
-    mockRefreshSession.mockResolvedValue({
+    mockSetSession.mockResolvedValue({
       data: {
         session: {
           access_token: 'new-access',
@@ -74,7 +79,8 @@ describe('AuthStore bootstrap auth', () => {
     expect(mockInvoke).toHaveBeenCalledWith('mobile-auth-bootstrap', {
       body: { action: 'claim', code: 'one-time-code' },
     });
-    expect(mockRefreshSession).toHaveBeenCalledWith({
+    expect(mockSetSession).toHaveBeenCalledWith({
+      access_token: 'server-access-token',
       refresh_token: 'server-refresh-token',
     });
     expect(useAuthStore.getState().user?.email).toBe('user@example.com');
@@ -92,6 +98,7 @@ describe('AuthStore bootstrap auth', () => {
 
     expect(success).toBe(false);
     expect(useAuthStore.getState().error).toBe('code expired');
+    expect(mockSetSession).not.toHaveBeenCalled();
     expect(mockRefreshSession).not.toHaveBeenCalled();
   });
 
@@ -145,11 +152,15 @@ describe('AuthStore bootstrap auth', () => {
     });
     controller.abort();
     resolveInvoke?.({
-      data: { refreshToken: 'server-refresh-token' },
+      data: {
+        accessToken: 'server-access-token',
+        refreshToken: 'server-refresh-token',
+      },
       error: null,
     });
 
     await expect(pending).resolves.toBe(false);
+    expect(mockSetSession).not.toHaveBeenCalled();
     expect(mockRefreshSession).not.toHaveBeenCalled();
     expect(useAuthStore.getState().error).toBeNull();
     expect(useAuthStore.getState().isLoading).toBe(false);

--- a/apps/mobile/src/stores/authStore.ts
+++ b/apps/mobile/src/stores/authStore.ts
@@ -130,11 +130,36 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
       if (error) throw error;
 
+      const accessToken =
+        data && typeof data.accessToken === 'string' ? data.accessToken : '';
       const refreshToken =
         data && typeof data.refreshToken === 'string' ? data.refreshToken : '';
 
+      if (accessToken && refreshToken) {
+        const { data: sessionData, error: sessionError } = await supabase.auth.setSession({
+          access_token: accessToken,
+          refresh_token: refreshToken,
+        });
+
+        if (options?.signal?.aborted) {
+          set({ isLoading: false });
+          return false;
+        }
+
+        if (sessionError) throw sessionError;
+
+        set({
+          session: sessionData.session,
+          user: sessionData.session?.user ?? null,
+          isLoading: false,
+        });
+
+        listenForAuthChanges(set);
+        return true;
+      }
+
       if (!refreshToken) {
-        throw new Error('Bootstrap response missing refresh token');
+        throw new Error('Bootstrap response missing session tokens');
       }
 
       return await get().signInWithToken(refreshToken, options);

--- a/supabase/functions/mobile-auth-bootstrap/index.ts
+++ b/supabase/functions/mobile-auth-bootstrap/index.ts
@@ -76,6 +76,9 @@ serve(async (req) => {
     const serviceRoleKey = getEnv('SUPABASE_SERVICE_ROLE_KEY');
     const bootstrapSecret = getEnv('MOBILE_AUTH_BOOTSTRAP_SECRET');
     const authHeader = req.headers.get('Authorization') ?? '';
+    const bearerToken = authHeader.startsWith('Bearer ')
+      ? authHeader.slice('Bearer '.length).trim()
+      : '';
 
     const serviceClient = createClient(supabaseUrl, serviceRoleKey);
     const authedClient = createClient(supabaseUrl, anonKey, {
@@ -94,10 +97,12 @@ serve(async (req) => {
     const nowIso = new Date().toISOString();
 
     if (body.action === 'create') {
+      const accessToken =
+        typeof body.accessToken === 'string' ? body.accessToken.trim() : bearerToken;
       const refreshToken =
         typeof body.refreshToken === 'string' ? body.refreshToken.trim() : '';
-      if (!refreshToken) {
-        return json(400, { error: 'refreshToken is required' });
+      if (!accessToken || !refreshToken) {
+        return json(400, { error: 'accessToken and refreshToken are required' });
       }
 
       const {
@@ -113,7 +118,10 @@ serve(async (req) => {
       const codeHash = await sha256(code);
       const expiresAt = new Date(Date.now() + BOOTSTRAP_TTL_MS).toISOString();
       const encryptedRefreshToken = await encryptBootstrapRefreshToken(
-        refreshToken,
+        JSON.stringify({
+          accessToken,
+          refreshToken,
+        }),
         bootstrapSecret
       );
 
@@ -226,12 +234,24 @@ serve(async (req) => {
         return json(410, { error: 'Bootstrap code is invalid or expired' });
       }
 
-      const refreshToken = await decryptBootstrapRefreshToken(
+      const sessionPayload = await decryptBootstrapRefreshToken(
         data.encrypted_refresh_token,
         bootstrapSecret
       );
+      const parsedPayload = JSON.parse(sessionPayload) as {
+        accessToken?: string;
+        refreshToken?: string;
+      };
+      const accessToken =
+        typeof parsedPayload.accessToken === 'string' ? parsedPayload.accessToken : '';
+      const refreshToken =
+        typeof parsedPayload.refreshToken === 'string' ? parsedPayload.refreshToken : '';
 
-      return json(200, { refreshToken });
+      if (!accessToken || !refreshToken) {
+        return json(500, { error: 'Stored bootstrap session payload is invalid' });
+      }
+
+      return json(200, { accessToken, refreshToken });
     }
 
     return json(400, { error: 'Unsupported action' });


### PR DESCRIPTION
## Summary
- return both access and refresh tokens from the bootstrap claim flow
- use supabase.auth.setSession on mobile bootstrap auth instead of refreshSession to avoid reusing an already-claimed refresh token
- keep the Edge Function backward-compatible by falling back to the Authorization bearer token when accessToken is not present in the create payload

## Testing
- pnpm --filter @tongil_kim/clautunnel test -- src/__tests__/mobile-auth-bootstrap.test.ts src/__tests__/mobile-auth-bootstrap-crypto.test.ts src/__tests__/mobile-auth-bootstrap-rate-limit.test.ts src/__tests__/mobile-server.test.ts
- pnpm --filter @clautunnel/mobile test
- pnpm --filter clautunnel-shared build
- pnpm --filter @tongil_kim/clautunnel build