### PR TITLE
refactor(auth): make CLI own mobile auth lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ This command does everything automatically:
 
 1. Open **Expo Go** on your phone
 2. Scan the **QR code** shown in your terminal
-3. Log in with the same email and password you used in `clautunnel signup`
-4. Tap **"+ New Session"** on your machine to start chatting with Claude
+3. The app signs in automatically using the one-time bootstrap code from `clautunnel start`
+4. To switch accounts or log out, use `clautunnel login` / `clautunnel logout` on the CLI
+5. Tap **"+ New Session"** on your machine to start chatting with Claude
 
 ## Development
 

--- a/apps/cli/src/__tests__/logout-command.test.ts
+++ b/apps/cli/src/__tests__/logout-command.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const mockSetSession = vi.fn();
+const mockSignOut = vi.fn();
+const loggerInfo = vi.fn();
+const loggerError = vi.fn();
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    auth: {
+      setSession: mockSetSession,
+      signOut: mockSignOut,
+    },
+  })),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  Logger: vi.fn().mockImplementation(() => ({
+    info: loggerInfo,
+    error: loggerError,
+  })),
+}));
+
+const TEST_CONFIG_DIR = join(tmpdir(), `clautunnel-logout-test-${Date.now()}`);
+
+vi.mock('../utils/config.js', async () => {
+  const actual = await vi.importActual('../utils/config.js');
+  return {
+    ...actual,
+    Config: class extends (actual as any).Config {
+      constructor() {
+        super(TEST_CONFIG_DIR);
+      }
+    },
+  };
+});
+
+describe('logout command', () => {
+  beforeEach(() => {
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_ANON_KEY = 'test-anon-key';
+
+    if (!existsSync(TEST_CONFIG_DIR)) {
+      mkdirSync(TEST_CONFIG_DIR, { recursive: true });
+    }
+
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_CONFIG_DIR)) {
+      rmSync(TEST_CONFIG_DIR, { recursive: true, force: true });
+    }
+    vi.resetModules();
+  });
+
+  it('globally signs out the Supabase session before clearing local tokens', async () => {
+    writeFileSync(
+      join(TEST_CONFIG_DIR, 'config.json'),
+      JSON.stringify({
+        sessionTokens: {
+          accessToken: 'stored-access-token',
+          refreshToken: 'stored-refresh-token',
+        },
+      })
+    );
+
+    mockSetSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: 'stored-access-token',
+          refresh_token: 'stored-refresh-token',
+        },
+      },
+      error: null,
+    });
+    mockSignOut.mockResolvedValue({ error: null });
+
+    const { createLogoutCommand } = await import('../commands/logout.js');
+    const command = createLogoutCommand();
+
+    await command.parseAsync(['node', 'logout'], { from: 'user' });
+
+    expect(mockSetSession).toHaveBeenCalledWith({
+      access_token: 'stored-access-token',
+      refresh_token: 'stored-refresh-token',
+    });
+    expect(mockSignOut).toHaveBeenCalledWith({ scope: 'global' });
+
+    const config = JSON.parse(readFileSync(join(TEST_CONFIG_DIR, 'config.json'), 'utf-8'));
+    expect(config.sessionTokens).toBeUndefined();
+    expect(loggerInfo).toHaveBeenCalledWith('Logged out successfully.');
+  });
+});

--- a/apps/cli/src/commands/logout.ts
+++ b/apps/cli/src/commands/logout.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
-import { Config } from '../utils/config.js';
+import { Config, ConfigurationError } from '../utils/config.js';
 import { Logger } from '../utils/logger.js';
+import { createSupabaseClient } from '../utils/supabase.js';
 
 export function createLogoutCommand(): Command {
   const command = new Command('logout');
@@ -15,8 +16,43 @@ export function createLogoutCommand(): Command {
       return;
     }
 
-    config.clearSessionTokens();
-    logger.info('Logged out successfully.');
+    try {
+      config.requireConfiguration();
+
+      const supabase = createSupabaseClient(
+        config.getSupabaseUrl(),
+        config.getSupabaseAnonKey()
+      );
+      const { error: sessionError } = await supabase.auth.setSession({
+        access_token: session.accessToken,
+        refresh_token: session.refreshToken,
+      });
+
+      // If the stored session is already invalid, clear the local copy anyway.
+      if (sessionError) {
+        config.clearSessionTokens();
+        logger.info('Stored session was already invalid. Cleared local auth.');
+        return;
+      }
+
+      const { error: signOutError } = await supabase.auth.signOut({ scope: 'global' });
+      if (signOutError) {
+        logger.error(`Logout failed: ${signOutError.message}`);
+        process.exit(1);
+      }
+
+      config.clearSessionTokens();
+      logger.info('Logged out successfully.');
+    } catch (error) {
+      if (error instanceof ConfigurationError) {
+        logger.error(error.message);
+        process.exit(1);
+      }
+      logger.error(
+        `Logout failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+      process.exit(1);
+    }
   });
 
   return command;

--- a/apps/mobile/.maestro/flows/session-detail/attachments.yaml
+++ b/apps/mobile/.maestro/flows/session-detail/attachments.yaml
@@ -2,17 +2,9 @@ appId: com.clautunnel.app
 ---
 - launchApp:
     clearState: true
-- tapOn:
-    id: "login-email-input"
-- inputText: "test@clautunnel.com"
-- tapOn:
-    id: "login-password-input"
-- inputText: "password123"
-- tapOn:
-    id: "login-button"
 - extendedWaitUntil:
     visible:
-      id: "session-card-test-session-1"
+      id: "sessions-stats-total"
     timeout: 5000
 - tapOn:
     id: "session-card-test-session-1"

--- a/apps/mobile/.maestro/flows/session-detail/connection-state.yaml
+++ b/apps/mobile/.maestro/flows/session-detail/connection-state.yaml
@@ -2,17 +2,9 @@ appId: com.clautunnel.app
 ---
 - launchApp:
     clearState: true
-- tapOn:
-    id: "login-email-input"
-- inputText: "test@clautunnel.com"
-- tapOn:
-    id: "login-password-input"
-- inputText: "password123"
-- tapOn:
-    id: "login-button"
 - extendedWaitUntil:
     visible:
-      id: "session-card-test-session-1"
+      id: "sessions-stats-total"
     timeout: 5000
 - tapOn:
     id: "session-card-test-session-1"

--- a/apps/mobile/.maestro/flows/session-detail/resume-history-dedupe.yaml
+++ b/apps/mobile/.maestro/flows/session-detail/resume-history-dedupe.yaml
@@ -2,17 +2,9 @@ appId: com.clautunnel.app
 ---
 - launchApp:
     clearState: true
-- tapOn:
-    id: "login-email-input"
-- inputText: "test@clautunnel.com"
-- tapOn:
-    id: "login-password-input"
-- inputText: "password123"
-- tapOn:
-    id: "login-button"
 - extendedWaitUntil:
     visible:
-      id: "session-card-test-session-1"
+      id: "sessions-stats-total"
     timeout: 5000
 - tapOn:
     id: "session-card-test-session-1"

--- a/apps/mobile/.maestro/flows/sessions/mutation-failures.yaml
+++ b/apps/mobile/.maestro/flows/sessions/mutation-failures.yaml
@@ -2,17 +2,9 @@ appId: com.clautunnel.app
 ---
 - launchApp:
     clearState: true
-- tapOn:
-    id: "login-email-input"
-- inputText: "test@clautunnel.com"
-- tapOn:
-    id: "login-password-input"
-- inputText: "password123"
-- tapOn:
-    id: "login-button"
 - extendedWaitUntil:
     visible:
-      id: "session-card-test-session-1"
+      id: "sessions-stats-total"
     timeout: 5000
 - tapOn:
     id: "test-mode-toggle"

--- a/apps/mobile/app/(auth)/index.tsx
+++ b/apps/mobile/app/(auth)/index.tsx
@@ -18,7 +18,7 @@ export default function ConnectScreen() {
           to open this app.
         </Text>
         <Text style={[styles.caption, isDark && styles.captionDark]}>
-          Mobile login and signup are managed from the CLI flow.
+          Login and logout are managed from the CLI flow.
         </Text>
       </View>
     </View>

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -35,7 +35,7 @@ export default function SettingsScreen() {
           </View>
           <View style={styles.noteRow}>
             <Text style={[styles.noteText, isDark && styles.noteTextDark]}>
-              Account access is managed from the CLI QR flow.
+              Login and logout are managed from the CLI.
             </Text>
           </View>
         </View>

--- a/apps/mobile/src/__tests__/auth-store-bootstrap.test.ts
+++ b/apps/mobile/src/__tests__/auth-store-bootstrap.test.ts
@@ -5,29 +5,6 @@ const mockOnAuthStateChange = vi.fn();
 const mockRefreshSession = vi.fn();
 const mockSetSession = vi.fn();
 const mockInvoke = vi.fn();
-const mockSignOut = vi.fn();
-const mockConnectionDisconnect = vi.fn().mockResolvedValue(undefined);
-const mockUnsubscribeFromPresence = vi.fn();
-const mockUnsubscribeMachinePresence = vi.fn();
-const mockSessionSetState = vi.fn();
-
-vi.mock('../stores/connectionStore', () => ({
-  useConnectionStore: {
-    getState: () => ({
-      disconnect: mockConnectionDisconnect,
-    }),
-  },
-}));
-
-vi.mock('../stores/sessionStore', () => ({
-  useSessionStore: {
-    getState: () => ({
-      unsubscribeFromPresence: mockUnsubscribeFromPresence,
-      unsubscribeMachinePresence: mockUnsubscribeMachinePresence,
-    }),
-    setState: mockSessionSetState,
-  },
-}));
 
 vi.mock('../services/supabase', () => ({
   supabase: {
@@ -36,7 +13,6 @@ vi.mock('../services/supabase', () => ({
       onAuthStateChange: mockOnAuthStateChange,
       refreshSession: mockRefreshSession,
       setSession: mockSetSession,
-      signOut: mockSignOut,
     },
     functions: {
       invoke: mockInvoke,
@@ -183,47 +159,8 @@ describe('AuthStore bootstrap auth', () => {
     expect(useAuthStore.getState().isLoading).toBe(false);
   });
 
-  it('clears local auth and session state immediately on sign out', async () => {
-    let resolveRemoteSignOut: (() => void) | null = null;
-    mockSignOut.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolveRemoteSignOut = () => resolve({ error: null });
-        })
-    );
-
+  it('does not expose a mobile signOut action', async () => {
     const { useAuthStore } = await import('../stores/authStore');
-
-    useAuthStore.setState({
-      user: { id: 'user-1', email: 'user@example.com' } as any,
-      session: { access_token: 'token', refresh_token: 'refresh' } as any,
-      isLoading: false,
-      error: null,
-    });
-
-    const pending = useAuthStore.getState().signOut();
-
-    expect(useAuthStore.getState().user).toBeNull();
-    expect(useAuthStore.getState().session).toBeNull();
-    expect(useAuthStore.getState().isLoading).toBe(false);
-    expect(mockUnsubscribeFromPresence).toHaveBeenCalledTimes(1);
-    expect(mockUnsubscribeMachinePresence).toHaveBeenCalledTimes(1);
-    expect(mockConnectionDisconnect).toHaveBeenCalledTimes(1);
-    expect(mockSessionSetState).toHaveBeenCalledWith({
-      sessions: [],
-      machines: [],
-      isLoading: false,
-      error: null,
-      pendingSessionId: null,
-      openSwipeableId: null,
-      sessionOnlineStatus: {},
-      machineOnlineStatus: {},
-      isStartingSession: null,
-      startSessionError: null,
-    });
-
-    resolveRemoteSignOut?.();
-    await expect(pending).resolves.toBeUndefined();
-    expect(mockSignOut).toHaveBeenCalledWith({ scope: 'global' });
+    expect((useAuthStore.getState() as Record<string, unknown>).signOut).toBeUndefined();
   });
 });

--- a/apps/mobile/src/__tests__/stores.test.ts
+++ b/apps/mobile/src/__tests__/stores.test.ts
@@ -20,7 +20,6 @@ vi.mock('../services/supabase', () => ({
     auth: {
       getSession: vi.fn(),
       onAuthStateChange: vi.fn(),
-      signOut: vi.fn(),
     },
     from: vi.fn(),
     channel: vi.fn(),

--- a/apps/mobile/src/stores/authStore.ts
+++ b/apps/mobile/src/stores/authStore.ts
@@ -1,8 +1,6 @@
 import { create } from 'zustand';
 import { supabase } from '../services/supabase';
 import type { User, Session } from '@supabase/supabase-js';
-import { useConnectionStore } from './connectionStore';
-import { useSessionStore } from './sessionStore';
 import {
   isTestMode,
   MOCK_USER,
@@ -19,7 +17,6 @@ interface AuthState {
   initialize: () => Promise<void>;
   claimBootstrapCode: (code: string, options?: { signal?: AbortSignal }) => Promise<boolean>;
   signInWithToken: (refreshToken: string, options?: { signal?: AbortSignal }) => Promise<boolean>;
-  signOut: () => Promise<void>;
   clearError: () => void;
 }
 
@@ -56,39 +53,6 @@ function getErrorMessage(error: unknown, fallback: string) {
 
 function isAbortError(error: unknown) {
   return error instanceof Error && error.name === 'AbortError';
-}
-
-function clearSessionStoreForSignOut() {
-  useSessionStore.getState().unsubscribeFromPresence();
-  useSessionStore.getState().unsubscribeMachinePresence();
-  useSessionStore.setState({
-    sessions: [],
-    machines: [],
-    isLoading: false,
-    error: null,
-    pendingSessionId: null,
-    openSwipeableId: null,
-    sessionOnlineStatus: {},
-    machineOnlineStatus: {},
-    isStartingSession: null,
-    startSessionError: null,
-  });
-}
-
-function applySignedOutState(set: (state: Partial<AuthState>) => void) {
-  clearSessionStoreForSignOut();
-  const disconnectResult = useConnectionStore.getState().disconnect();
-  if (disconnectResult && typeof disconnectResult.then === 'function') {
-    void disconnectResult.catch(() => {
-      // Best-effort channel cleanup.
-    });
-  }
-  set({
-    session: null,
-    user: null,
-    isLoading: false,
-    error: null,
-  });
 }
 
 let _authSubscription: { unsubscribe: () => void } | null = null;
@@ -251,22 +215,6 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         isLoading: false,
       });
       return false;
-    }
-  },
-
-  signOut: async () => {
-    if (_testMode) {
-      applySignedOutState(set);
-      return;
-    }
-
-    set({ isLoading: true, error: null });
-    applySignedOutState(set);
-
-    try {
-      await supabase.auth.signOut({ scope: 'global' });
-    } catch (error) {
-      console.warn('[authStore] Remote sign-out failed:', getErrorMessage(error, 'Unknown sign-out error'));
     }
   },
 


### PR DESCRIPTION
## Summary
- make `clautunnel logout` perform a global Supabase sign-out before clearing local tokens
- remove the remaining mobile-side logout API so auth ownership stays with the CLI bootstrap flow
- update README and Maestro flows to match the current CLI-managed mobile auth path

## Testing
- pnpm --filter clautunnel-shared build
- pnpm --filter @tongil_kim/clautunnel test -- src/__tests__/logout-command.test.ts
- pnpm --filter @clautunnel/mobile test -- src/__tests__/auth-store-bootstrap.test.ts
- pnpm --filter @tongil_kim/clautunnel test -- src/__tests__/commands.test.ts src/__tests__/commands-auth.test.ts
- pnpm --filter @clautunnel/mobile test -- src/__tests__/stores.test.ts