### PR TITLE
chore: update Sonnet 4.5 → Sonnet 4.6

### DIFF
--- a/apps/cli/src/daemon/daemon.ts
+++ b/apps/cli/src/daemon/daemon.ts
@@ -300,7 +300,7 @@ export class Daemon extends EventEmitter {
         if (previousModel !== message.model) {
           const modelNames: Record<string, string> = {
             'default': 'Opus 4.6',
-            'sonnet': 'Sonnet 4.5',
+            'sonnet': 'Sonnet 4.6',
             'opus': 'Opus 4.6',
             'haiku': 'Haiku 3.5',
           };

--- a/apps/cli/src/daemon/sdk-session.ts
+++ b/apps/cli/src/daemon/sdk-session.ts
@@ -915,7 +915,7 @@ export class SdkSession extends EventEmitter {
     const coreModels: ModelInfo[] = [
       { value: 'opus', displayName: 'Opus 4.6', description: 'Opus 4.6 · Most capable for complex work' },
       { value: 'haiku', displayName: 'Haiku 4.5', description: 'Haiku 4.5 · Fastest for quick answers' },
-      { value: 'sonnet', displayName: 'Sonnet 4.5', description: 'Sonnet 4.5 · Best for everyday tasks' },
+      { value: 'sonnet', displayName: 'Sonnet 4.6', description: 'Sonnet 4.6 · Best for everyday tasks' },
     ];
 
     // Return cached SDK models if available

--- a/apps/mobile/.maestro/flows/session-detail/model-change-loading.yaml
+++ b/apps/mobile/.maestro/flows/session-detail/model-change-loading.yaml
@@ -44,7 +44,7 @@ appId: com.clautunnel.app
 
 # Verify badge updated to Sonnet (not still showing Opus)
 - extendedWaitUntil:
-    visible: "Sonnet 4"
+    visible: "Sonnet 4.6"
     timeout: 3000
 - assertNotVisible: "Opus 4.6"
 

--- a/apps/mobile/src/__tests__/model-badge.test.ts
+++ b/apps/mobile/src/__tests__/model-badge.test.ts
@@ -7,7 +7,7 @@ import { getModelBadgeState } from '../utils/modelBadgeState';
 const sampleModels: ModelInfo[] = [
   { value: 'opus', displayName: 'Opus 4.6', description: 'Claude Opus 4.6 — most capable' },
   { value: 'haiku', displayName: 'Haiku 3.5', description: 'Claude Haiku 3.5 — fastest' },
-  { value: 'sonnet', displayName: 'Sonnet 4.5', description: 'Claude Sonnet 4.5 — balanced performance' },
+  { value: 'sonnet', displayName: 'Sonnet 4.6', description: 'Claude Sonnet 4.6 — balanced performance' },
 ];
 
 describe('getModelDisplayName', () => {
@@ -20,14 +20,14 @@ describe('getModelDisplayName', () => {
       expect(getModelDisplayName('haiku', sampleModels)).toBe('Haiku 3.5');
     });
 
-    it('should return "Sonnet 4.5" for model "sonnet"', () => {
-      expect(getModelDisplayName('sonnet', sampleModels)).toBe('Sonnet 4.5');
+    it('should return "Sonnet 4.6" for model "sonnet"', () => {
+      expect(getModelDisplayName('sonnet', sampleModels)).toBe('Sonnet 4.6');
     });
   });
 
   describe('returns correct display name for full model identifiers', () => {
-    it('should return "Sonnet 4.5" for full sonnet identifier', () => {
-      expect(getModelDisplayName('claude-sonnet-4-5-20250929', sampleModels)).toBe('Sonnet 4.5');
+    it('should return "Sonnet 4.6" for full sonnet identifier', () => {
+      expect(getModelDisplayName('claude-sonnet-4-6', sampleModels)).toBe('Sonnet 4.6');
     });
 
     it('should return "Opus 4.6" for full opus identifier', () => {
@@ -64,8 +64,8 @@ describe('getModelDisplayName', () => {
     });
 
     it('should resolve full sonnet identifier via sonnet shorthand entry', () => {
-      const result = getModelDisplayName('claude-sonnet-4-5-20250929', sampleModels);
-      expect(result).toBe('Sonnet 4.5');
+      const result = getModelDisplayName('claude-sonnet-4-6', sampleModels);
+      expect(result).toBe('Sonnet 4.6');
     });
 
     it('should resolve full haiku identifier via haiku shorthand entry', () => {
@@ -165,13 +165,13 @@ describe('getModelBadgeState', () => {
       });
       expect(during.showSpinner).toBe(true);
 
-      // After: Sonnet 4.5
+      // After: Sonnet 4.6
       const after = getModelBadgeState({
         model: 'sonnet',
         availableModels: sampleModels,
         isModelChanging: false,
       });
-      expect(after.displayText).toBe('Sonnet 4.5');
+      expect(after.displayText).toBe('Sonnet 4.6');
       expect(after.showSpinner).toBe(false);
     });
   });

--- a/apps/mobile/src/components/ModelPicker.tsx
+++ b/apps/mobile/src/components/ModelPicker.tsx
@@ -126,6 +126,8 @@ export function ModelPicker({
                       >
                         {model.value === 'opus'
                           ? 'claude-opus-4-6'
+                          : model.value === 'sonnet'
+                          ? 'claude-sonnet-4-6'
                           : model.value === 'haiku'
                           ? 'claude-3-5-haiku-20241022'
                           : model.value}

--- a/apps/mobile/src/utils/testMode.ts
+++ b/apps/mobile/src/utils/testMode.ts
@@ -159,7 +159,7 @@ export const MOCK_MODELS: ModelInfo[] = [
   },
   {
     value: 'sonnet',
-    displayName: 'Sonnet 4',
+    displayName: 'Sonnet 4.6',
     description: 'Fast, balanced default model',
   },
   {


### PR DESCRIPTION
## Summary
- Update all Sonnet display names from 4.5 to 4.6 across CLI and mobile apps
- Add explicit `claude-sonnet-4-6` full model identifier in ModelPicker (was falling through to just `'sonnet'`)
- Update test fixtures and Maestro E2E flow assertions to match

## Test plan
- [x] CLI tests pass (410 tests)
- [x] Mobile tests pass (248 tests)
- [ ] Verify Maestro E2E flow for model-change-loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)